### PR TITLE
feat(crud): Row-level addRow / updateRow / removeRow with lifecycle callbacks

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2602,6 +2602,98 @@ class TableCrafter {
   }
 
   /**
+   * Row-level CRUD API
+   *
+   * Public methods documented in the README. Each method:
+   *   - validates permissions (when enabled)
+   *   - delegates to the API-aware *Entry helpers when api.baseUrl is set
+   *   - mutates this.data
+   *   - fires the matching lifecycle callback
+   *   - re-renders
+   */
+
+  async addRow(rowData) {
+    if (!this.hasPermission('create')) {
+      throw new Error('TableCrafter: permission denied for create');
+    }
+
+    let row;
+    if (this.config.api && this.config.api.baseUrl) {
+      row = await this.createEntry(rowData);
+    } else {
+      row = rowData;
+      this.data.push(row);
+    }
+
+    const index = this.data.length - 1;
+
+    if (typeof this.config.onAdd === 'function') {
+      this.config.onAdd({ row, index });
+    }
+
+    this.render();
+    return row;
+  }
+
+  async updateRow(index, rowData) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`TableCrafter: row index ${index} out of range`);
+    }
+
+    const previous = { ...this.data[index] };
+
+    if (!this.hasPermission('edit', this.data[index])) {
+      throw new Error('TableCrafter: permission denied for edit');
+    }
+
+    let row;
+    if (this.config.api && this.config.api.baseUrl) {
+      row = await this.updateEntry(index, rowData);
+    } else {
+      row = { ...previous, ...rowData };
+      this.data[index] = row;
+    }
+
+    if (typeof this.config.onUpdate === 'function') {
+      this.config.onUpdate({ row, index, previous });
+    }
+
+    this.render();
+    return row;
+  }
+
+  async removeRow(index, options = {}) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`TableCrafter: row index ${index} out of range`);
+    }
+
+    const row = this.data[index];
+
+    if (!this.hasPermission('delete', row)) {
+      throw new Error('TableCrafter: permission denied for delete');
+    }
+
+    if (options.confirm && typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      if (!window.confirm('Are you sure you want to delete this row?')) {
+        return false;
+      }
+    }
+
+    if (this.config.api && this.config.api.baseUrl) {
+      await this.deleteEntry(index);
+    } else {
+      this.data.splice(index, 1);
+    }
+
+    if (typeof this.config.onDelete === 'function') {
+      this.config.onDelete({ row, index });
+    }
+
+    this.render();
+    return true;
+  }
+
+  /**
    * Lookup Fields System
    */
 

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -1,0 +1,232 @@
+/**
+ * Row-level CRUD methods tests (issue #66, sub-issue of #64)
+ *
+ * Covers public addRow / updateRow / removeRow API:
+ *   - mutation of internal data
+ *   - re-render
+ *   - lifecycle callbacks (onAdd / onUpdate / onDelete)
+ *   - API delegation when config.api.baseUrl is set
+ *   - permission gating
+ *   - bounds checking
+ *   - removeRow confirm flow (accept + cancel)
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseColumns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+const seedData = () => [
+  { id: 1, name: 'Alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob', email: 'bob@example.com' }
+];
+
+const makeTable = (overrides = {}) => {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data: seedData(),
+    columns: baseColumns,
+    ...overrides
+  });
+};
+
+describe('TableCrafter row-level CRUD', () => {
+  describe('addRow', () => {
+    test('exposes addRow as a function', () => {
+      const table = makeTable();
+      expect(typeof table.addRow).toBe('function');
+    });
+
+    test('appends row, fires onAdd, and re-renders', async () => {
+      const onAdd = jest.fn();
+      const table = makeTable({ onAdd });
+      const renderSpy = jest.spyOn(table, 'render');
+
+      const newRow = { id: 3, name: 'Carol', email: 'carol@example.com' };
+      const result = await table.addRow(newRow);
+
+      expect(table.getData()).toHaveLength(3);
+      expect(table.getData()[2]).toEqual(newRow);
+      expect(result).toEqual(newRow);
+      expect(onAdd).toHaveBeenCalledTimes(1);
+      expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
+        row: newRow,
+        index: 2
+      }));
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    test('delegates to API createEntry when api.baseUrl is set', async () => {
+      const table = makeTable({
+        api: {
+          baseUrl: 'https://api.example.com',
+          endpoints: { data: '/data', create: '/create', update: '/update', delete: '/delete', lookup: '/lookup' }
+        }
+      });
+      const newRow = { name: 'Dave', email: 'dave@example.com' };
+      const apiResponse = { id: 99, ...newRow };
+      const createSpy = jest.spyOn(table, 'createEntry').mockResolvedValue(apiResponse);
+
+      const result = await table.addRow(newRow);
+
+      expect(createSpy).toHaveBeenCalledWith(newRow);
+      expect(result).toEqual(apiResponse);
+    });
+
+    test('rejects when permissions deny create', async () => {
+      const table = makeTable({
+        permissions: { enabled: true, view: ['*'], edit: ['*'], delete: ['*'], create: ['admin'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.addRow({ id: 9, name: 'X', email: 'x@x.com' }))
+        .rejects.toThrow(/permission/i);
+      expect(table.getData()).toHaveLength(2);
+    });
+  });
+
+  describe('updateRow', () => {
+    test('exposes updateRow as a function', () => {
+      const table = makeTable();
+      expect(typeof table.updateRow).toBe('function');
+    });
+
+    test('merges fields, fires onUpdate with previous, re-renders', async () => {
+      const onUpdate = jest.fn();
+      const table = makeTable({ onUpdate });
+      const renderSpy = jest.spyOn(table, 'render');
+      const previous = { ...table.getData()[0] };
+
+      const result = await table.updateRow(0, { name: 'Alicia' });
+
+      expect(table.getData()[0]).toEqual({ ...previous, name: 'Alicia' });
+      expect(result).toEqual({ ...previous, name: 'Alicia' });
+      expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
+        row: { ...previous, name: 'Alicia' },
+        index: 0,
+        previous
+      }));
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    test('delegates to API updateEntry when api.baseUrl is set', async () => {
+      const table = makeTable({
+        api: {
+          baseUrl: 'https://api.example.com',
+          endpoints: { data: '/data', create: '/create', update: '/update', delete: '/delete', lookup: '/lookup' }
+        }
+      });
+      const apiResponse = { id: 1, name: 'Alicia', email: 'alice@example.com' };
+      const updateSpy = jest.spyOn(table, 'updateEntry').mockResolvedValue(apiResponse);
+
+      const result = await table.updateRow(0, { name: 'Alicia' });
+
+      expect(updateSpy).toHaveBeenCalledWith(0, { name: 'Alicia' });
+      expect(result).toEqual(apiResponse);
+    });
+
+    test('throws RangeError on out-of-range index', async () => {
+      const table = makeTable();
+      await expect(table.updateRow(99, { name: 'Z' }))
+        .rejects.toThrow(RangeError);
+      await expect(table.updateRow(-1, { name: 'Z' }))
+        .rejects.toThrow(RangeError);
+    });
+
+    test('rejects when permissions deny edit', async () => {
+      const table = makeTable({
+        permissions: { enabled: true, view: ['*'], edit: ['admin'], delete: ['*'], create: ['*'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.updateRow(0, { name: 'X' }))
+        .rejects.toThrow(/permission/i);
+      expect(table.getData()[0].name).toBe('Alice');
+    });
+  });
+
+  describe('removeRow', () => {
+    test('exposes removeRow as a function', () => {
+      const table = makeTable();
+      expect(typeof table.removeRow).toBe('function');
+    });
+
+    test('removes entry, fires onDelete, re-renders, resolves true', async () => {
+      const onDelete = jest.fn();
+      const table = makeTable({ onDelete });
+      const renderSpy = jest.spyOn(table, 'render');
+      const target = { ...table.getData()[0] };
+
+      const result = await table.removeRow(0);
+
+      expect(result).toBe(true);
+      expect(table.getData()).toHaveLength(1);
+      expect(table.getData()[0].id).toBe(2);
+      expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({
+        row: target,
+        index: 0
+      }));
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    test('honours { confirm: true } and resolves false on cancel', async () => {
+      const onDelete = jest.fn();
+      const table = makeTable({ onDelete });
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+      const result = await table.removeRow(0, { confirm: true });
+
+      expect(result).toBe(false);
+      expect(table.getData()).toHaveLength(2);
+      expect(onDelete).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    test('honours { confirm: true } and proceeds on accept', async () => {
+      const onDelete = jest.fn();
+      const table = makeTable({ onDelete });
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+      const result = await table.removeRow(0, { confirm: true });
+
+      expect(result).toBe(true);
+      expect(table.getData()).toHaveLength(1);
+      expect(onDelete).toHaveBeenCalledTimes(1);
+      confirmSpy.mockRestore();
+    });
+
+    test('delegates to API deleteEntry when api.baseUrl is set', async () => {
+      const table = makeTable({
+        api: {
+          baseUrl: 'https://api.example.com',
+          endpoints: { data: '/data', create: '/create', update: '/update', delete: '/delete', lookup: '/lookup' }
+        }
+      });
+      const deleteSpy = jest.spyOn(table, 'deleteEntry').mockResolvedValue(true);
+
+      const result = await table.removeRow(0);
+
+      expect(deleteSpy).toHaveBeenCalledWith(0);
+      expect(result).toBe(true);
+    });
+
+    test('throws RangeError on out-of-range index', async () => {
+      const table = makeTable();
+      await expect(table.removeRow(99)).rejects.toThrow(RangeError);
+      await expect(table.removeRow(-1)).rejects.toThrow(RangeError);
+    });
+
+    test('rejects when permissions deny delete', async () => {
+      const table = makeTable({
+        permissions: { enabled: true, view: ['*'], edit: ['*'], delete: ['admin'], create: ['*'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.removeRow(0)).rejects.toThrow(/permission/i);
+      expect(table.getData()).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements public row-level CRUD methods documented in README but missing from `src/`: `addRow`, `updateRow`, `removeRow`.
- Each method is permission-aware (`config.permissions.enabled`), delegates to existing `createEntry` / `updateEntry` / `deleteEntry` when `config.api.baseUrl` is set, fires `onAdd` / `onUpdate` / `onDelete` lifecycle callbacks, and re-renders.
- `removeRow(index, { confirm: true })` shows a `window.confirm` prompt; cancel resolves `false` with no mutation, no API call, no callback.
- `updateRow` / `removeRow` throw `RangeError` for out-of-range indices.
- 16 new tests in `test/crud.test.js`. Existing suite stays green (one pre-existing unrelated failure in `tablecrafter.test.js` left untouched).

Closes [#66](https://github.com/TableCrafter/tablecrafter/issues/66) — sub-issue of [#64](https://github.com/TableCrafter/tablecrafter/issues/64) Gravity Tables CRUD Refinement.

## TDD trace
1. Wrote `test/crud.test.js` first — all 16 tests failed with `TypeError: table.addRow is not a function` etc.
2. Implemented the three methods in `src/tablecrafter.js` (~90 lines, between `deleteEntry` and the lookup section).
3. All 16 new tests pass; full suite: 77 passed, 1 pre-existing unrelated failure.

## Test plan
- [x] `npm test` — 77 passing (1 pre-existing failure on `loadData` fetch signal mismatch is unrelated to this PR)
- [x] `addRow` success + onAdd payload + render
- [x] `addRow` API delegation (mocked `createEntry`)
- [x] `addRow` permission rejection
- [x] `updateRow` merge + onUpdate payload (with `previous`) + render
- [x] `updateRow` API delegation, RangeError, permission rejection
- [x] `removeRow` mutation + onDelete payload + render + resolves true
- [x] `removeRow` confirm: cancel path returns false, no callback, no mutation
- [x] `removeRow` confirm: accept path proceeds normally
- [x] `removeRow` API delegation, RangeError, permission rejection