### PR TITLE
feat(crud): row-level addRow / updateRow / removeRow with lifecycle callbacks (#66)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2602,6 +2602,125 @@ class TableCrafter {
   }
 
   /**
+   * Row-level CRUD methods
+   *
+   * Public, Promise-based API for programmatic row mutation. They sit on top
+   * of `createEntry` / `updateEntry` / `deleteEntry` so that REST delegation
+   * still works when `config.api.baseUrl` is set.
+   */
+
+  /**
+   * Append a row to the table.
+   *
+   * Resolves to the persisted row (server response when API is configured,
+   * otherwise the local payload). Fires `config.onAdd({ row, index })`.
+   */
+  async addRow(rowData) {
+    if (this.config.permissions && this.config.permissions.enabled &&
+        !this.hasPermission('create')) {
+      throw new Error('Permission denied: cannot create row');
+    }
+
+    const beforeLen = this.data.length;
+    let persisted;
+
+    if (this.config.api && this.config.api.baseUrl) {
+      // createEntry pushes the server response into this.data
+      persisted = await this.createEntry(rowData);
+    } else {
+      this.data.push(rowData);
+      persisted = rowData;
+    }
+
+    const index = beforeLen;
+
+    this.render();
+
+    if (typeof this.config.onAdd === 'function') {
+      this.config.onAdd({ row: persisted, index });
+    }
+
+    return persisted;
+  }
+
+  /**
+   * Update fields on a single row.
+   *
+   * Resolves to the updated row. Fires
+   * `config.onUpdate({ row, index, previous })`. Throws `RangeError` if the
+   * index is out of range.
+   */
+  async updateRow(index, rowData) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`updateRow: index ${index} is out of range`);
+    }
+
+    if (this.config.permissions && this.config.permissions.enabled &&
+        !this.hasPermission('edit', this.data[index])) {
+      throw new Error('Permission denied: cannot edit row');
+    }
+
+    const previous = { ...this.data[index] };
+    let updated;
+
+    if (this.config.api && this.config.api.baseUrl) {
+      updated = await this.updateEntry(index, rowData);
+    } else {
+      this.data[index] = { ...this.data[index], ...rowData };
+      updated = this.data[index];
+    }
+
+    this.render();
+
+    if (typeof this.config.onUpdate === 'function') {
+      this.config.onUpdate({ row: updated, index, previous });
+    }
+
+    return updated;
+  }
+
+  /**
+   * Remove a single row.
+   *
+   * Resolves to `true` on success. With `{ confirm: true }`, prompts via
+   * `window.confirm()` and resolves `false` if the user cancels — no API
+   * call, callback, or re-render in that case.
+   */
+  async removeRow(index, options = {}) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`removeRow: index ${index} is out of range`);
+    }
+
+    if (this.config.permissions && this.config.permissions.enabled &&
+        !this.hasPermission('delete', this.data[index])) {
+      throw new Error('Permission denied: cannot delete row');
+    }
+
+    if (options.confirm === true) {
+      // Parity with bulkDelete: bail out without side effects on cancel.
+      if (!confirm('Are you sure you want to delete this row?')) {
+        return false;
+      }
+    }
+
+    const target = this.data[index];
+
+    if (this.config.api && this.config.api.baseUrl) {
+      await this.deleteEntry(index);
+    } else {
+      this.data.splice(index, 1);
+    }
+
+    this.render();
+
+    if (typeof this.config.onDelete === 'function') {
+      this.config.onDelete({ row: target, index });
+    }
+
+    return true;
+  }
+
+  /**
    * Lookup Fields System
    */
 

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -1,0 +1,355 @@
+/**
+ * Row-level CRUD methods (addRow / updateRow / removeRow)
+ *
+ * Sub-issue of #64, tracked in #66.
+ *
+ * These tests are intentionally written first (TDD). They drive the
+ * implementation of `table.addRow`, `table.updateRow`, and `table.removeRow`
+ * in `src/tablecrafter.js`.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseColumns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+function makeData() {
+  return [
+    { id: 1, name: 'Alice', email: 'alice@example.com' },
+    { id: 2, name: 'Bob', email: 'bob@example.com' },
+    { id: 3, name: 'Carol', email: 'carol@example.com' }
+  ];
+}
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data: makeData(),
+    columns: baseColumns,
+    ...extra
+  });
+}
+
+describe('addRow', () => {
+  test('exists as a public method', () => {
+    const table = makeTable();
+    expect(typeof table.addRow).toBe('function');
+  });
+
+  test('appends row to this.data and resolves to the row', async () => {
+    const table = makeTable();
+    const newRow = { id: 4, name: 'Dan', email: 'dan@example.com' };
+
+    const result = await table.addRow(newRow);
+
+    expect(table.data).toHaveLength(4);
+    expect(table.data[3]).toEqual(newRow);
+    expect(result).toEqual(newRow);
+  });
+
+  test('returns a Promise', () => {
+    const table = makeTable();
+    const ret = table.addRow({ id: 99, name: 'X', email: 'x@x' });
+    expect(ret).toBeInstanceOf(Promise);
+    return ret;
+  });
+
+  test('re-renders after success', async () => {
+    const table = makeTable();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.addRow({ id: 4, name: 'Dan', email: 'dan@example.com' });
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires config.onAdd with { row, index }', async () => {
+    const onAdd = jest.fn();
+    const table = makeTable({ onAdd });
+    const newRow = { id: 4, name: 'Dan', email: 'dan@example.com' };
+
+    await table.addRow(newRow);
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ row: newRow, index: 3 })
+    );
+  });
+
+  test('delegates to createEntry when api.baseUrl is configured', async () => {
+    const created = { id: 99, name: 'Server', email: 's@s.com' };
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => created
+    });
+
+    const table = makeTable({
+      api: { baseUrl: 'https://example.test', endpoints: { create: '/create' } }
+    });
+
+    const result = await table.addRow({ name: 'Server', email: 's@s.com' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = fetch.mock.calls[0];
+    expect(url).toBe('https://example.test/create');
+    expect(options.method).toBe('POST');
+    // Server response wins as the persisted row
+    expect(result).toEqual(created);
+    expect(table.data[table.data.length - 1]).toEqual(created);
+  });
+
+  test('rejects with permission error when permissions.enabled and user lacks create', async () => {
+    const table = makeTable({
+      permissions: {
+        enabled: true,
+        view: ['*'],
+        edit: ['*'],
+        delete: ['*'],
+        create: ['admin']
+      }
+    });
+    table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+    await expect(
+      table.addRow({ id: 4, name: 'Dan', email: 'd@d' })
+    ).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('updateRow', () => {
+  test('exists as a public method', () => {
+    const table = makeTable();
+    expect(typeof table.updateRow).toBe('function');
+  });
+
+  test('merges fields into this.data[index] and resolves to the row', async () => {
+    const table = makeTable();
+    const result = await table.updateRow(1, { name: 'Bobby' });
+
+    expect(table.data[1]).toEqual({
+      id: 2,
+      name: 'Bobby',
+      email: 'bob@example.com'
+    });
+    expect(result).toEqual(table.data[1]);
+  });
+
+  test('returns a Promise', () => {
+    const table = makeTable();
+    const ret = table.updateRow(0, { name: 'AA' });
+    expect(ret).toBeInstanceOf(Promise);
+    return ret;
+  });
+
+  test('re-renders after success', async () => {
+    const table = makeTable();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.updateRow(0, { name: 'Alicia' });
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires config.onUpdate with { row, index, previous }', async () => {
+    const onUpdate = jest.fn();
+    const table = makeTable({ onUpdate });
+    const previousSnapshot = { ...table.data[0] };
+
+    await table.updateRow(0, { name: 'Alicia' });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: table.data[0],
+        index: 0,
+        previous: previousSnapshot
+      })
+    );
+  });
+
+  test('delegates to updateEntry when api.baseUrl is configured', async () => {
+    const updated = { id: 1, name: 'Alicia', email: 'alice@example.com' };
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => updated
+    });
+
+    const table = makeTable({
+      api: { baseUrl: 'https://example.test', endpoints: { update: '/update' } }
+    });
+
+    const result = await table.updateRow(0, { name: 'Alicia' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = fetch.mock.calls[0];
+    expect(url).toBe('https://example.test/update/1');
+    expect(options.method).toBe('PUT');
+    expect(result).toEqual(updated);
+    expect(table.data[0]).toEqual(updated);
+  });
+
+  test('rejects with RangeError on out-of-range index', async () => {
+    const table = makeTable();
+    await expect(table.updateRow(99, { name: 'X' })).rejects.toBeInstanceOf(RangeError);
+    await expect(table.updateRow(-1, { name: 'X' })).rejects.toBeInstanceOf(RangeError);
+  });
+
+  test('rejects with permission error when user lacks edit', async () => {
+    const table = makeTable({
+      permissions: {
+        enabled: true,
+        view: ['*'],
+        edit: ['admin'],
+        delete: ['*'],
+        create: ['*']
+      }
+    });
+    table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+    await expect(table.updateRow(0, { name: 'X' })).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('removeRow', () => {
+  test('exists as a public method', () => {
+    const table = makeTable();
+    expect(typeof table.removeRow).toBe('function');
+  });
+
+  test('removes this.data[index] and resolves to true', async () => {
+    const table = makeTable();
+    const removed = table.data[1];
+
+    const result = await table.removeRow(1);
+
+    expect(result).toBe(true);
+    expect(table.data).toHaveLength(2);
+    expect(table.data).not.toContain(removed);
+  });
+
+  test('returns a Promise', () => {
+    const table = makeTable();
+    const ret = table.removeRow(0);
+    expect(ret).toBeInstanceOf(Promise);
+    return ret;
+  });
+
+  test('re-renders after success', async () => {
+    const table = makeTable();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.removeRow(0);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires config.onDelete with { row, index }', async () => {
+    const onDelete = jest.fn();
+    const table = makeTable({ onDelete });
+    const target = { ...table.data[1] };
+
+    await table.removeRow(1);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ row: target, index: 1 })
+    );
+  });
+
+  test('delegates to deleteEntry when api.baseUrl is configured', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    });
+
+    const table = makeTable({
+      api: { baseUrl: 'https://example.test', endpoints: { delete: '/delete' } }
+    });
+
+    const result = await table.removeRow(0);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = fetch.mock.calls[0];
+    expect(url).toBe('https://example.test/delete/1');
+    expect(options.method).toBe('DELETE');
+    expect(result).toBe(true);
+    expect(table.data).toHaveLength(2);
+  });
+
+  test('with { confirm: true } and user accepts: deletes and resolves true', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDelete = jest.fn();
+    const table = makeTable({ onDelete });
+
+    const result = await table.removeRow(0, { confirm: true });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(table.data).toHaveLength(2);
+
+    confirmSpy.mockRestore();
+  });
+
+  test('with { confirm: true } and user cancels: resolves false, no mutation, no callback, no API call', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const onDelete = jest.fn();
+    const renderBefore = jest.fn();
+    const table = makeTable({
+      onDelete,
+      api: { baseUrl: 'https://example.test', endpoints: { delete: '/delete' } }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    const result = await table.removeRow(0, { confirm: true });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(result).toBe(false);
+    expect(table.data).toHaveLength(3);
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  test('rejects with RangeError on out-of-range index', async () => {
+    const table = makeTable();
+    await expect(table.removeRow(99)).rejects.toBeInstanceOf(RangeError);
+    await expect(table.removeRow(-1)).rejects.toBeInstanceOf(RangeError);
+  });
+
+  test('rejects with permission error when user lacks delete', async () => {
+    const table = makeTable({
+      permissions: {
+        enabled: true,
+        view: ['*'],
+        edit: ['*'],
+        delete: ['admin'],
+        create: ['*']
+      }
+    });
+    table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+    await expect(table.removeRow(0)).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('CRUD methods do not break existing API', () => {
+  test('createEntry / updateEntry / deleteEntry still exist', () => {
+    const table = makeTable();
+    expect(typeof table.createEntry).toBe('function');
+    expect(typeof table.updateEntry).toBe('function');
+    expect(typeof table.deleteEntry).toBe('function');
+  });
+
+  test('bulkDelete still exists', () => {
+    const table = makeTable();
+    expect(typeof table.bulkDelete).toBe('function');
+  });
+
+  test('cell-level onEdit callback still fires (regression guard)', () => {
+    const onEdit = jest.fn();
+    const table = makeTable({ editable: true, onEdit });
+    // saveCellEdit is the internal hook that fires onEdit;
+    // we just assert the registered callback is the one we passed.
+    expect(table.config.onEdit).toBe(onEdit);
+  });
+});


### PR DESCRIPTION
Closes #66 (sub-issue of #64).

## Summary

- Adds three Promise-based row-level CRUD methods to `TableCrafter`:
  - `table.addRow(rowData)` → resolves to the persisted row, fires `config.onAdd({ row, index })`.
  - `table.updateRow(index, rowData)` → merges fields, fires `config.onUpdate({ row, index, previous })`.
  - `table.removeRow(index, { confirm? })` → resolves `true` on success, `false` if a confirm prompt is cancelled. Fires `config.onDelete({ row, index })`.
- Each method delegates to the existing `createEntry / updateEntry / deleteEntry` when `config.api.baseUrl` is set, so REST endpoints are still hit. Otherwise mutations stay local.
- Permission-aware: when `config.permissions.enabled`, the methods reject with a clear `Error` if the current user lacks `create / edit / delete`.
- Bounds-checked: `updateRow` and `removeRow` throw `RangeError` on out-of-range indices.
- All three re-render on success. `removeRow({ confirm: true })` matches `bulkDelete`'s `window.confirm()` flow — cancel is a clean no-op (no API call, no callback, no render).

Existing public API and behaviour (`createEntry`, `updateEntry`, `deleteEntry`, `bulkDelete`, cell-level `onEdit`) is unchanged.

## TDD

Tests landed first in `test/crud.test.js` (28 cases). They covered every acceptance criterion before any implementation existed; the suite went RED, then implementation drove it to GREEN.

## Test plan

- [x] `npx jest test/crud.test.js` → 28/28 pass
- [x] Full suite shows no regressions vs. `main` (the one pre-existing `should load data from URL` failure in `tablecrafter.test.js` is unrelated and reproduces on `main` without this change)

## Out of scope

- Inline edit/delete buttons in the rendered table (separate refinement).
- Optimistic update / rollback (phase 2).
- WordPress wrapper integration (#54).