### PR TITLE
feat(crud): Row-level addRow/updateRow/removeRow with lifecycle callbacks (#66)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tablecrafter",
-  "version": "1.6.0",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tablecrafter",
-      "version": "1.6.0",
+      "version": "1.6.5",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2602,6 +2602,94 @@ class TableCrafter {
   }
 
   /**
+   * Public row-level CRUD API (issue #66)
+   * Thin lifecycle-aware wrappers around create/update/deleteEntry that
+   * the README has long advertised.
+   */
+  async addRow(rowData) {
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('create')) {
+      throw new Error('Permission denied: cannot create entries');
+    }
+
+    const created = await this.createEntry(rowData || {});
+    const index = this.data.length - 1;
+
+    this.render();
+
+    if (typeof this.config.onAdd === 'function') {
+      this.config.onAdd({
+        row: created,
+        index,
+        // Backwards-compat keys for the existing modal-driven onAdd consumers.
+        newEntry: created,
+        totalEntries: this.data.length
+      });
+    }
+
+    return created;
+  }
+
+  async updateRow(index, rowData) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`updateRow: index ${index} is out of range`);
+    }
+
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('edit', this.data[index])) {
+      throw new Error('Permission denied: cannot edit this entry');
+    }
+
+    const previous = { ...this.data[index] };
+    const merged = { ...previous, ...(rowData || {}) };
+
+    let updated;
+    if (this.config.api && this.config.api.baseUrl) {
+      updated = await this.updateEntry(index, merged);
+    } else {
+      this.data[index] = merged;
+      updated = this.data[index];
+    }
+
+    this.render();
+
+    if (typeof this.config.onUpdate === 'function') {
+      this.config.onUpdate({ row: updated, index, previous });
+    }
+
+    return updated;
+  }
+
+  async removeRow(index, options = {}) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`removeRow: index ${index} is out of range`);
+    }
+
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('delete', this.data[index])) {
+      throw new Error('Permission denied: cannot delete this entry');
+    }
+
+    if (options && options.confirm === true) {
+      const proceed = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Are you sure you want to delete this row?')
+        : true;
+      if (!proceed) {
+        return false;
+      }
+    }
+
+    const removed = { ...this.data[index] };
+
+    await this.deleteEntry(index);
+
+    this.render();
+
+    if (typeof this.config.onDelete === 'function') {
+      this.config.onDelete({ row: removed, index });
+    }
+
+    return true;
+  }
+
+  /**
    * Lookup Fields System
    */
 

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -1,0 +1,287 @@
+/**
+ * Row-level CRUD tests for issue #66 / parent #64
+ *
+ * Covers public methods:
+ *   - table.addRow(rowData)
+ *   - table.updateRow(index, rowData)
+ *   - table.removeRow(index, options?)
+ *
+ * Lifecycle callbacks: onAdd, onUpdate, onDelete
+ * API delegation, permission gating, and bounds checking.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseColumns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+function seed() {
+  return [
+    { id: 1, name: 'Alice', email: 'alice@example.com' },
+    { id: 2, name: 'Bob', email: 'bob@example.com' },
+    { id: 3, name: 'Carol', email: 'carol@example.com' }
+  ];
+}
+
+function setup(extraConfig = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data: seed(),
+    columns: baseColumns,
+    ...extraConfig
+  });
+}
+
+describe('Row-level CRUD: addRow', () => {
+  test('exposes addRow as a function', () => {
+    const table = setup();
+    expect(typeof table.addRow).toBe('function');
+  });
+
+  test('appends row to data and resolves to the added entry', async () => {
+    const table = setup();
+    const before = table.data.length;
+    const newRow = { id: 4, name: 'Dave', email: 'dave@example.com' };
+
+    const result = await table.addRow(newRow);
+
+    expect(table.data.length).toBe(before + 1);
+    expect(table.data[table.data.length - 1]).toMatchObject(newRow);
+    expect(result).toMatchObject(newRow);
+  });
+
+  test('re-renders after adding', async () => {
+    const table = setup();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.addRow({ id: 4, name: 'Dave' });
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires onAdd lifecycle callback with { row, index }', async () => {
+    const onAdd = jest.fn();
+    const table = setup({ onAdd });
+    const newRow = { id: 4, name: 'Dave' };
+
+    await table.addRow(newRow);
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    const payload = onAdd.mock.calls[0][0];
+    expect(payload).toEqual(expect.objectContaining({
+      row: expect.objectContaining({ id: 4, name: 'Dave' }),
+      index: 3
+    }));
+  });
+
+  test('delegates to createEntry when api.baseUrl is configured', async () => {
+    const table = setup({
+      api: { baseUrl: 'https://api.example.com', endpoints: { create: '/create' } }
+    });
+    const apiResponse = { id: 99, name: 'Server' };
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => apiResponse
+    });
+
+    const result = await table.addRow({ name: 'Server' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.example.com/create',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result).toMatchObject(apiResponse);
+    expect(table.data[table.data.length - 1]).toMatchObject(apiResponse);
+  });
+
+  test('rejects when permissions enabled and user lacks create role', async () => {
+    const table = setup({
+      permissions: { enabled: true, view: ['*'], create: ['admin'], edit: ['*'], delete: ['*'] }
+    });
+    table.setCurrentUser({ id: 7, roles: ['viewer'] });
+
+    await expect(table.addRow({ id: 4, name: 'Dave' })).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('Row-level CRUD: updateRow', () => {
+  test('exposes updateRow as a function', () => {
+    const table = setup();
+    expect(typeof table.updateRow).toBe('function');
+  });
+
+  test('merges fields into entry and resolves to updated row', async () => {
+    const table = setup();
+    const result = await table.updateRow(1, { name: 'Bobby' });
+
+    expect(table.data[1]).toEqual({ id: 2, name: 'Bobby', email: 'bob@example.com' });
+    expect(result).toEqual({ id: 2, name: 'Bobby', email: 'bob@example.com' });
+  });
+
+  test('re-renders after update', async () => {
+    const table = setup();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.updateRow(0, { name: 'Alicia' });
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires onUpdate with { row, index, previous }', async () => {
+    const onUpdate = jest.fn();
+    const table = setup({ onUpdate });
+    const previousSnapshot = { ...table.data[1] };
+
+    await table.updateRow(1, { name: 'Bobby' });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const payload = onUpdate.mock.calls[0][0];
+    expect(payload.index).toBe(1);
+    expect(payload.row).toEqual(expect.objectContaining({ name: 'Bobby' }));
+    expect(payload.previous).toEqual(previousSnapshot);
+  });
+
+  test('delegates to updateEntry when api.baseUrl is configured', async () => {
+    const table = setup({
+      api: { baseUrl: 'https://api.example.com', endpoints: { update: '/update' } }
+    });
+    const apiResponse = { id: 2, name: 'Bobby', email: 'bob@example.com' };
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => apiResponse
+    });
+
+    const result = await table.updateRow(1, { name: 'Bobby' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.example.com/update/2',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    expect(result).toMatchObject(apiResponse);
+  });
+
+  test('rejects with RangeError on out-of-range index', async () => {
+    const table = setup();
+    await expect(table.updateRow(99, { name: 'X' })).rejects.toBeInstanceOf(RangeError);
+    await expect(table.updateRow(-1, { name: 'X' })).rejects.toBeInstanceOf(RangeError);
+  });
+
+  test('rejects when permissions enabled and user lacks edit role', async () => {
+    const table = setup({
+      permissions: { enabled: true, view: ['*'], edit: ['admin'], create: ['*'], delete: ['*'] }
+    });
+    table.setCurrentUser({ id: 7, roles: ['viewer'] });
+
+    await expect(table.updateRow(0, { name: 'X' })).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('Row-level CRUD: removeRow', () => {
+  test('exposes removeRow as a function', () => {
+    const table = setup();
+    expect(typeof table.removeRow).toBe('function');
+  });
+
+  test('removes row at index and resolves to true', async () => {
+    const table = setup();
+    const result = await table.removeRow(1);
+
+    expect(result).toBe(true);
+    expect(table.data.length).toBe(2);
+    expect(table.data.find(r => r.id === 2)).toBeUndefined();
+  });
+
+  test('re-renders after removal', async () => {
+    const table = setup();
+    const renderSpy = jest.spyOn(table, 'render');
+    await table.removeRow(0);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('fires onDelete with { row, index }', async () => {
+    const onDelete = jest.fn();
+    const table = setup({ onDelete });
+    const removedSnapshot = { ...table.data[2] };
+
+    await table.removeRow(2);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    const payload = onDelete.mock.calls[0][0];
+    expect(payload.index).toBe(2);
+    expect(payload.row).toEqual(removedSnapshot);
+  });
+
+  test('delegates to deleteEntry when api.baseUrl is configured', async () => {
+    const table = setup({
+      api: { baseUrl: 'https://api.example.com', endpoints: { delete: '/delete' } }
+    });
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    });
+
+    const result = await table.removeRow(0);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.example.com/delete/1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(result).toBe(true);
+  });
+
+  test('honours { confirm: true } - cancel path resolves false without mutation', async () => {
+    const onDelete = jest.fn();
+    const table = setup({ onDelete });
+    const renderSpy = jest.spyOn(table, 'render');
+    const beforeLen = table.data.length;
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    const result = await table.removeRow(0, { confirm: true });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(result).toBe(false);
+    expect(table.data.length).toBe(beforeLen);
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(renderSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  test('honours { confirm: true } - accept path proceeds normally', async () => {
+    const onDelete = jest.fn();
+    const table = setup({ onDelete });
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const result = await table.removeRow(0, { confirm: true });
+
+    expect(result).toBe(true);
+    expect(table.data.length).toBe(2);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+
+    confirmSpy.mockRestore();
+  });
+
+  test('rejects with RangeError on out-of-range index', async () => {
+    const table = setup();
+    await expect(table.removeRow(99)).rejects.toBeInstanceOf(RangeError);
+    await expect(table.removeRow(-1)).rejects.toBeInstanceOf(RangeError);
+  });
+
+  test('rejects when permissions enabled and user lacks delete role', async () => {
+    const table = setup({
+      permissions: { enabled: true, view: ['*'], edit: ['*'], create: ['*'], delete: ['admin'] }
+    });
+    table.setCurrentUser({ id: 7, roles: ['viewer'] });
+
+    await expect(table.removeRow(0)).rejects.toThrow(/permission/i);
+  });
+});
+
+describe('Row-level CRUD: existing API preserved', () => {
+  test('createEntry/updateEntry/deleteEntry/bulkDelete still exist', () => {
+    const table = setup();
+    expect(typeof table.createEntry).toBe('function');
+    expect(typeof table.updateEntry).toBe('function');
+    expect(typeof table.deleteEntry).toBe('function');
+    expect(typeof table.bulkDelete).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the public row-level CRUD API documented in `README.md` but missing from `src/tablecrafter.js`. Closes #66 (sub-issue of #64).

- `table.addRow(rowData)` — appends a row, delegates to `createEntry` when an API is configured, fires `onAdd({ row, index })`, re-renders.
- `table.updateRow(index, rowData)` — merges fields, delegates to `updateEntry` when an API is configured, fires `onUpdate({ row, index, previous })`, re-renders. `RangeError` on bad index.
- `table.removeRow(index, options?)` — delegates to `deleteEntry`, fires `onDelete({ row, index })`, re-renders, resolves `true`. `{ confirm: true }` shows a `window.confirm()` prompt; cancel resolves `false` with no callback / no API call / no render. `RangeError` on bad index.
- All three reject with a permission error when `permissions.enabled` is true and the current user lacks the relevant role.

## Backwards compatibility

- `createEntry`, `updateEntry`, `deleteEntry`, `bulkDelete`, and the cell-level `onEdit` callback are unchanged.
- The legacy modal-driven `onAdd` payload (`{ newEntry, totalEntries }`) is preserved alongside the new `{ row, index }` shape, so existing consumers of `onAdd` keep working.

## TDD

Tests were written first in `test/crud.test.js` (23 cases) and confirmed red before the implementation landed. They cover, per method:

- Promise return shape and `data` mutation.
- `render()` re-invocation (via spy).
- Lifecycle callback payloads.
- API delegation with mocked `fetch` (POST/PUT/DELETE to `/create`, `/update/:id`, `/delete/:id`).
- `removeRow` confirm accept + cancel paths (mocked `window.confirm`).
- `RangeError` for out-of-range indices on update/remove.
- Permission rejection when `permissions.enabled` and user lacks role.

## Test plan

- [x] `npm test` — 23 new tests pass; full suite is 84 passing / 1 pre-existing unrelated failure (`should load data from URL` retries `fetch` twice — predates this PR, see commit history).
- [ ] Manual smoke in `examples/` once published.

## Out of scope (per issue)

- UI-driven edit/delete buttons in the rendered table.
- Optimistic update / rollback.
- WordPress wrapper integration (#54).