### PR TITLE
feat(sort): Multi-column sorting with priority indicators (#45)

### DIFF
--- a/src/tablecrafter.css
+++ b/src/tablecrafter.css
@@ -60,6 +60,22 @@
   font-size: 12px;
 }
 
+.tc-sort-priority {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 5px;
+  min-width: 14px;
+  height: 14px;
+  line-height: 14px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  background-color: #007bff;
+  border-radius: 7px;
+  text-align: center;
+  vertical-align: middle;
+}
+
 .tc-editable {
   cursor: pointer;
   border: 2px solid transparent;

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -130,6 +130,7 @@ class TableCrafter {
     this.currentPage = this.config.currentPage || 1;
     this.sortField = null;
     this.sortOrder = 'asc';
+    this.sortKeys = [];
     this.filters = {};
     this.searchTerm = '';
     this.isLoading = false;
@@ -729,23 +730,34 @@ class TableCrafter {
       if (this.config.sortable && column.sortable !== false) {
         th.className = 'tc-sortable';
         th.tabIndex = 0; // Make focusable
-        
-        // helper to get aria-sort state
+
+        // Determine this column's role in the current sort.
+        const sortKeyIndex = this.sortKeys.findIndex(k => k.field === column.field);
         let sortState = 'none';
-        if (this.sortField === column.field) {
-            sortState = this.sortOrder === 'asc' ? 'ascending' : 'descending';
+        if (sortKeyIndex === 0) {
+          sortState = this.sortKeys[0].direction === 'asc' ? 'ascending' : 'descending';
+        } else if (sortKeyIndex > 0) {
+          sortState = 'other';
         }
         th.setAttribute('aria-sort', sortState);
 
-        // Click handler
-        th.addEventListener('click', () => this.sort(column.field));
-        
-        // Keyboard handler (Enter/Space)
+        // Priority badge for multi-sort.
+        if (sortKeyIndex >= 0 && this.sortKeys.length > 1) {
+          const badge = document.createElement('span');
+          badge.className = 'tc-sort-priority';
+          badge.textContent = String(sortKeyIndex + 1);
+          th.appendChild(badge);
+        }
+
+        th.addEventListener('click', (e) => {
+          this.sort(column.field, { append: !!e.shiftKey });
+        });
+
         th.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                this.sort(column.field);
-            }
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.sort(column.field, { append: !!e.shiftKey });
+          }
         });
       }
 
@@ -2031,27 +2043,96 @@ class TableCrafter {
   }
 
   /**
-   * Sort data
+   * Sort data by one or more columns.
+   *
+   * sort(field)                                — replace sort with single key (toggles direction on repeat).
+   * sort(field, { append: true })              — append/toggle key in multi-sort list.
+   * sort(field, { direction: 'asc' | 'desc' }) — set explicit direction.
    */
-  sort(field) {
-    if (this.sortField === field) {
-      this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+  sort(field, options = {}) {
+    const append = options.append === true;
+    const explicitDirection = options.direction;
+
+    if (append) {
+      const existing = this.sortKeys.find(k => k.field === field);
+      if (existing) {
+        existing.direction = explicitDirection
+          ? explicitDirection
+          : (existing.direction === 'asc' ? 'desc' : 'asc');
+      } else {
+        this.sortKeys.push({ field, direction: explicitDirection || 'asc' });
+      }
     } else {
-      this.sortField = field;
-      this.sortOrder = 'asc';
+      const current = this.sortKeys[0];
+      if (!explicitDirection && current && current.field === field && this.sortKeys.length === 1) {
+        this.sortKeys = [{ field, direction: current.direction === 'asc' ? 'desc' : 'asc' }];
+      } else {
+        this.sortKeys = [{ field, direction: explicitDirection || 'asc' }];
+      }
     }
 
-    this.data.sort((a, b) => {
-      const aVal = a[field];
-      const bVal = b[field];
+    this._applySortKeys();
+  }
 
-      if (aVal === bVal) return 0;
+  /**
+   * Set the entire sort key list at once.
+   */
+  multiSort(keys) {
+    if (!Array.isArray(keys)) {
+      throw new TypeError('multiSort: keys must be an array');
+    }
+    this.sortKeys = keys.map(k => ({
+      field: k.field,
+      direction: k.direction === 'desc' ? 'desc' : 'asc'
+    }));
+    this._applySortKeys();
+  }
 
-      const result = aVal < bVal ? -1 : 1;
-      return this.sortOrder === 'asc' ? result : -result;
-    });
+  /**
+   * Apply current sortKeys to this.data with a stable composite comparator,
+   * sync legacy sortField/sortOrder, persist state, and re-render.
+   */
+  _applySortKeys() {
+    const primary = this.sortKeys[0];
+    this.sortField = primary ? primary.field : null;
+    this.sortOrder = primary ? primary.direction : 'asc';
 
-    // Reset to first page after sorting
+    if (this.sortKeys.length > 0) {
+      const columnsByField = {};
+      (this.config.columns || []).forEach(col => { columnsByField[col.field] = col; });
+
+      // Stamp original index for guaranteed stability.
+      const indexed = this.data.map((row, idx) => ({ row, idx }));
+
+      indexed.sort((a, b) => {
+        for (const key of this.sortKeys) {
+          const col = columnsByField[key.field];
+          let cmp;
+          if (col && typeof col.compare === 'function') {
+            cmp = col.compare(a.row[key.field], b.row[key.field], a.row, b.row);
+          } else {
+            const aVal = a.row[key.field];
+            const bVal = b.row[key.field];
+            if (aVal === bVal) {
+              cmp = 0;
+            } else if (aVal === null || aVal === undefined) {
+              cmp = 1;
+            } else if (bVal === null || bVal === undefined) {
+              cmp = -1;
+            } else {
+              cmp = aVal < bVal ? -1 : 1;
+            }
+          }
+          if (cmp !== 0) {
+            return key.direction === 'desc' ? -cmp : cmp;
+          }
+        }
+        return a.idx - b.idx;
+      });
+
+      this.data = indexed.map(entry => entry.row);
+    }
+
     this.currentPage = 1;
     this.saveState();
     this.render();
@@ -2769,6 +2850,7 @@ class TableCrafter {
       filters: this.filters,
       sortField: this.sortField,
       sortOrder: this.sortOrder,
+      sortKeys: this.sortKeys,
       currentPage: this.currentPage,
       selectedRows: Array.from(this.selectedRows),
       timestamp: Date.now()
@@ -2800,8 +2882,19 @@ class TableCrafter {
 
       // Restore state
       this.filters = state.filters || {};
-      this.sortField = state.sortField;
-      this.sortOrder = state.sortOrder || 'asc';
+      if (Array.isArray(state.sortKeys) && state.sortKeys.length > 0) {
+        this.sortKeys = state.sortKeys.map(k => ({
+          field: k.field,
+          direction: k.direction === 'desc' ? 'desc' : 'asc'
+        }));
+      } else if (state.sortField) {
+        // Legacy state migration.
+        this.sortKeys = [{ field: state.sortField, direction: state.sortOrder || 'asc' }];
+      } else {
+        this.sortKeys = [];
+      }
+      this.sortField = this.sortKeys[0] ? this.sortKeys[0].field : null;
+      this.sortOrder = this.sortKeys[0] ? this.sortKeys[0].direction : 'asc';
       this.currentPage = state.currentPage || 1;
       this.selectedRows = new Set(state.selectedRows || []);
 

--- a/test/multi-sort.test.js
+++ b/test/multi-sort.test.js
@@ -1,0 +1,332 @@
+/**
+ * Multi-column sorting tests for issue #45
+ *
+ * Covers:
+ *   - this.sortKeys ordered list
+ *   - sort(field, { append, direction })
+ *   - multiSort([{ field, direction }, ...])
+ *   - Stable composite ordering
+ *   - Per-column custom comparator (column.compare)
+ *   - Shift+click DOM wiring
+ *   - aria-sort + .tc-sort-priority indicators
+ *   - State persistence (incl. legacy migration)
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const peopleColumns = [
+  { field: 'department', label: 'Department' },
+  { field: 'lastName', label: 'Last Name' },
+  { field: 'firstName', label: 'First Name' },
+  { field: 'salary', label: 'Salary' }
+];
+
+function people() {
+  return [
+    { id: 1, department: 'Eng', lastName: 'Smith', firstName: 'Bob', salary: 100 },
+    { id: 2, department: 'Eng', lastName: 'Smith', firstName: 'Alice', salary: 90 },
+    { id: 3, department: 'Sales', lastName: 'Jones', firstName: 'Carol', salary: 80 },
+    { id: 4, department: 'Eng', lastName: 'Adams', firstName: 'Dave', salary: 110 },
+    { id: 5, department: 'Sales', lastName: 'Jones', firstName: 'Bob', salary: 85 }
+  ];
+}
+
+function setup(extraConfig = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data: people(),
+    columns: peopleColumns,
+    sortable: true,
+    ...extraConfig
+  });
+}
+
+describe('Multi-column sort: state shape', () => {
+  test('sortKeys is initialized as an empty array', () => {
+    const table = setup();
+    expect(Array.isArray(table.sortKeys)).toBe(true);
+    expect(table.sortKeys.length).toBe(0);
+  });
+
+  test('legacy sortField/sortOrder mirror sortKeys[0]', () => {
+    const table = setup();
+    table.sort('department');
+    expect(table.sortKeys).toEqual([{ field: 'department', direction: 'asc' }]);
+    expect(table.sortField).toBe('department');
+    expect(table.sortOrder).toBe('asc');
+  });
+});
+
+describe('Multi-column sort: sort(field, options)', () => {
+  test('sort(field) without options replaces sortKeys with a single entry', () => {
+    const table = setup();
+    table.sort('department');
+    table.sort('lastName');
+    expect(table.sortKeys).toEqual([{ field: 'lastName', direction: 'asc' }]);
+  });
+
+  test('sort(field) toggles direction on repeat without options', () => {
+    const table = setup();
+    table.sort('department');
+    table.sort('department');
+    expect(table.sortKeys).toEqual([{ field: 'department', direction: 'desc' }]);
+  });
+
+  test('sort(field, { append: true }) appends a new key', () => {
+    const table = setup();
+    table.sort('department');
+    table.sort('lastName', { append: true });
+    expect(table.sortKeys).toEqual([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'asc' }
+    ]);
+  });
+
+  test('append-mode toggles direction on existing field, no duplicate', () => {
+    const table = setup();
+    table.sort('department');
+    table.sort('lastName', { append: true });
+    table.sort('lastName', { append: true });
+    expect(table.sortKeys).toEqual([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'desc' }
+    ]);
+  });
+
+  test('explicit direction is honoured', () => {
+    const table = setup();
+    table.sort('salary', { direction: 'desc' });
+    expect(table.sortKeys).toEqual([{ field: 'salary', direction: 'desc' }]);
+  });
+});
+
+describe('Multi-column sort: multiSort()', () => {
+  test('exposes multiSort as a function', () => {
+    const table = setup();
+    expect(typeof table.multiSort).toBe('function');
+  });
+
+  test('replaces sortKeys with the provided array', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'desc' }
+    ]);
+    expect(table.sortKeys).toEqual([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'desc' }
+    ]);
+  });
+
+  test('throws TypeError on non-array input', () => {
+    const table = setup();
+    expect(() => table.multiSort('department')).toThrow(TypeError);
+    expect(() => table.multiSort(null)).toThrow(TypeError);
+  });
+});
+
+describe('Multi-column sort: composite ordering', () => {
+  test('secondary key breaks ties on primary key', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'asc' }
+    ]);
+    // Eng group: Adams, Smith, Smith. Sales group: Jones, Jones.
+    const order = table.data.map(r => `${r.department}/${r.lastName}/${r.firstName}`);
+    expect(order).toEqual([
+      'Eng/Adams/Dave',
+      'Eng/Smith/Bob',
+      'Eng/Smith/Alice',
+      'Sales/Jones/Carol',
+      'Sales/Jones/Bob'
+    ]);
+  });
+
+  test('three-key sort: department asc, lastName asc, firstName asc', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'asc' },
+      { field: 'firstName', direction: 'asc' }
+    ]);
+    const order = table.data.map(r => r.id);
+    // Eng/Adams/Dave(4), Eng/Smith/Alice(2), Eng/Smith/Bob(1), Sales/Jones/Bob(5), Sales/Jones/Carol(3)
+    expect(order).toEqual([4, 2, 1, 5, 3]);
+  });
+
+  test('descending direction reverses key order', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'salary', direction: 'desc' }
+    ]);
+    const eng = table.data.filter(r => r.department === 'Eng').map(r => r.salary);
+    expect(eng).toEqual([110, 100, 90]);
+  });
+
+  test('sort is stable: ties across all keys preserve original order', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const data = [
+      { id: 'a', group: 'X' },
+      { id: 'b', group: 'X' },
+      { id: 'c', group: 'X' },
+      { id: 'd', group: 'X' }
+    ];
+    const table = new TableCrafter('#t', {
+      data,
+      columns: [{ field: 'group', label: 'G' }, { field: 'id', label: 'ID' }],
+      sortable: true
+    });
+    table.sort('group'); // all equal
+    expect(table.data.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+describe('Multi-column sort: custom comparator', () => {
+  test('column.compare is used when provided', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    // Reverse-length comparator on a string field
+    const data = [
+      { id: 1, label: 'short' },
+      { id: 2, label: 'medium-long' },
+      { id: 3, label: 'tiny' },
+      { id: 4, label: 'a-very-long-label' }
+    ];
+    const compare = jest.fn((a, b) => a.length - b.length);
+    const table = new TableCrafter('#t', {
+      data,
+      columns: [
+        { field: 'id', label: 'ID' },
+        { field: 'label', label: 'Label', compare }
+      ],
+      sortable: true
+    });
+    table.sort('label');
+    expect(compare).toHaveBeenCalled();
+    expect(table.data.map(r => r.id)).toEqual([3, 1, 2, 4]);
+  });
+});
+
+describe('Multi-column sort: DOM event wiring', () => {
+  test('shift+click on header triggers append-mode sort', () => {
+    const table = setup();
+    table.sort('department');
+
+    const header = document.querySelector('th[data-field="lastName"]');
+    expect(header).not.toBeNull();
+    header.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+
+    expect(table.sortKeys).toEqual([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'asc' }
+    ]);
+  });
+
+  test('plain click on header replaces sort (single-column behaviour)', () => {
+    const table = setup();
+    table.sort('department');
+    table.sort('lastName', { append: true });
+
+    const header = document.querySelector('th[data-field="firstName"]');
+    header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(table.sortKeys).toEqual([{ field: 'firstName', direction: 'asc' }]);
+  });
+});
+
+describe('Multi-column sort: accessibility & priority indicators', () => {
+  test('primary key gets aria-sort=ascending; secondary gets aria-sort=other', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'desc' }
+    ]);
+
+    const dept = document.querySelector('th[data-field="department"]');
+    const last = document.querySelector('th[data-field="lastName"]');
+    const first = document.querySelector('th[data-field="firstName"]');
+
+    expect(dept.getAttribute('aria-sort')).toBe('ascending');
+    expect(last.getAttribute('aria-sort')).toBe('other');
+    expect(first.getAttribute('aria-sort')).toBe('none');
+  });
+
+  test('priority badge appears on each sorted header when multi-sorting', () => {
+    const table = setup();
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'lastName', direction: 'asc' }
+    ]);
+
+    const deptBadge = document.querySelector('th[data-field="department"] .tc-sort-priority');
+    const lastBadge = document.querySelector('th[data-field="lastName"] .tc-sort-priority');
+    expect(deptBadge).not.toBeNull();
+    expect(lastBadge).not.toBeNull();
+    expect(deptBadge.textContent).toBe('1');
+    expect(lastBadge.textContent).toBe('2');
+  });
+
+  test('priority badge is absent for single-column sort', () => {
+    const table = setup();
+    table.sort('department');
+    const badge = document.querySelector('th[data-field="department"] .tc-sort-priority');
+    expect(badge).toBeNull();
+  });
+});
+
+describe('Multi-column sort: state persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('sortKeys round-trips through save/load', () => {
+    const table = setup({
+      state: { persist: true, storage: 'localStorage', key: 'tc-multi-sort-test' }
+    });
+    table.multiSort([
+      { field: 'department', direction: 'asc' },
+      { field: 'salary', direction: 'desc' }
+    ]);
+    table.saveState();
+
+    document.body.innerHTML = '<div id="t"></div>';
+    const reloaded = new TableCrafter('#t', {
+      data: people(),
+      columns: peopleColumns,
+      sortable: true,
+      state: { persist: true, storage: 'localStorage', key: 'tc-multi-sort-test' }
+    });
+
+    expect(reloaded.sortKeys).toEqual([
+      { field: 'department', direction: 'asc' },
+      { field: 'salary', direction: 'desc' }
+    ]);
+  });
+
+  test('legacy { sortField, sortOrder } state migrates to sortKeys on load', () => {
+    localStorage.setItem(
+      'tc-legacy-sort-test',
+      JSON.stringify({
+        filters: {},
+        sortField: 'department',
+        sortOrder: 'desc',
+        currentPage: 1,
+        selectedRows: [],
+        timestamp: Date.now()
+      })
+    );
+
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: people(),
+      columns: peopleColumns,
+      sortable: true,
+      state: { persist: true, storage: 'localStorage', key: 'tc-legacy-sort-test' }
+    });
+
+    expect(table.sortKeys).toEqual([{ field: 'department', direction: 'desc' }]);
+    expect(table.sortField).toBe('department');
+    expect(table.sortOrder).toBe('desc');
+  });
+});


### PR DESCRIPTION
## Summary

Implements multi-column sorting on top of the existing single-column sort. Closes #45 (acceptance criteria + TDD plan added in [this comment](https://github.com/TableCrafter/tablecrafter/issues/45#issuecomment-4335818512) before any code landed).

### Public API

- `table.sort(field, options?)`
  - `options.append: true` — appends `field` to the sort key list, toggling direction in place if already present.
  - `options.direction: 'asc' | 'desc'` — sets an explicit direction.
  - Default (no options) preserves current behaviour: replace + toggle.
- `table.multiSort([{ field, direction }, …])` — replace the entire sort key list. Throws `TypeError` on non-array input.

### Behaviour

- New `this.sortKeys` ordered list holds the active sort. `sortField` / `sortOrder` continue to mirror `sortKeys[0]` so existing reads and the persisted-state shape stay compatible.
- Composite comparator walks `sortKeys` in priority order. Per-column `columns[].compare(aVal, bVal, aRow, bRow)` overrides the default when present.
- Sort is **stable across all engines** via an explicit original-index tiebreaker (not relying on V8-specific guarantees).
- Header rendering:
  - Shift+click (and Shift+Enter / Shift+Space when focused) wires to append-mode sort.
  - Primary key → `aria-sort=ascending|descending`. Additional keys → `aria-sort=other`.
  - A `.tc-sort-priority` numeric badge appears on each sorted header when more than one key is active. CSS for the badge added to `tablecrafter.css`.
- `saveState` / `loadState` persist `sortKeys`. Legacy `{ sortField, sortOrder }` state migrates transparently on load.

### TDD

Tests written first in `test/multi-sort.test.js` (22 cases) and confirmed red before implementation. Coverage:

- State shape (init, legacy mirror).
- `sort` replace/toggle/append semantics.
- `multiSort` replacement + `TypeError` on non-array.
- Composite ordering across two and three keys, with descending mixed in.
- Stability under all-equal keys (preserves original order).
- Custom `column.compare`.
- Shift+click vs plain click on `<th>` (synthesised `MouseEvent` with `shiftKey`).
- `aria-sort` values + `.tc-sort-priority` badge presence and absence.
- State round-trip and legacy migration.

## Test plan

- [x] `npm test` — 22 new tests pass; full suite is **106 passing / 1 pre-existing unrelated failure** (`should load data from URL`, predates this PR).
- [ ] Visual smoke once published — confirm priority badges render correctly under the existing theme.

## Out of scope

- UI for re-ordering / removing individual keys (drag handles, "clear all" button) — phase 2.
- Server-side sort negotiation in API mode — separate ticket.