### PR TITLE
fix(loadData): Pass AbortSignal to fetch, cancel superseded loads (#71)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -327,59 +327,68 @@ class TableCrafter {
    * Load data from URL
    */
   async loadData() {
+    if (this._loadController) {
+      this._loadController.abort();
+    }
+    const controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+    this._loadController = controller;
+    const signal = controller ? controller.signal : undefined;
+
     this.isLoading = true;
     this.renderLoading();
 
-    // If SSR mode is enabled and content exists, handle hydration logic
     if (this.container.dataset.ssr === "true") {
-      // this.render(); // <-- REMOVED: Do not wipe server content yet!
       if (this.data && this.data.length > 0) {
-      // Vital: Initialize internal state so future renders (sorting/filtering) work!
-      this.data = this.processData(this.data);
-      this.autoDiscoverColumns();
-      this.detectFilterTypes();
-      
-      this.container.dataset.ssr = "false";
-      this.hydrateListeners(); // Attach listeners to existing DOM
-      this.isLoading = false;
-      return Promise.resolve(this.data);
-    }
+        this.data = this.processData(this.data);
+        this.autoDiscoverColumns();
+        this.detectFilterTypes();
+        this.container.dataset.ssr = "false";
+        this.hydrateListeners();
+        this.isLoading = false;
+        return Promise.resolve(this.data);
+      }
       if (this.dataUrl) {
-         try {
-           const response = await fetch(this.dataUrl);
-           if (!response.ok) throw new Error(`HTTP ${response.status}`);
-           const data = await response.json();
-           this.data = this.processData(data);
-           this.autoDiscoverColumns();
-           this.detectFilterTypes();
-           this.container.dataset.ssr = "false";
-           this.render();
-         } catch (e) {
-           console.error('TableCrafter: Hydration failed', e);
-           // Silent fail for hydration is okay, user sees SSR content
-         }
+        try {
+          const response = await fetch(this.dataUrl, { signal });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const data = await response.json();
+          this.data = this.processData(data);
+          this.autoDiscoverColumns();
+          this.detectFilterTypes();
+          this.container.dataset.ssr = "false";
+          this.render();
+        } catch (e) {
+          if (e && e.name === 'AbortError') {
+            return this.data;
+          }
+          console.error('TableCrafter: Hydration failed', e);
+        }
       }
       this.isLoading = false;
       return this.data;
     }
 
-    // Standard Client-Side Load
     try {
-      const response = await fetch(this.dataUrl);
+      const response = await fetch(this.dataUrl, { signal });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
-      this.data = this.processData(data); // Using processData for consistency
-      
+      this.data = this.processData(data);
       this.autoDiscoverColumns();
       this.render();
     } catch (error) {
+      if (error && error.name === 'AbortError') {
+        return this.data;
+      }
       console.error('TableCrafter: Load failed', error);
       this.renderError('Unable to load data. The source may be unavailable.');
       throw error;
     } finally {
-      this.isLoading = false;
+      if (this._loadController === controller) {
+        this.isLoading = false;
+        this._loadController = null;
+      }
     }
   }
 

--- a/test/tablecrafter.test.js
+++ b/test/tablecrafter.test.js
@@ -115,6 +115,35 @@ describe('TableCrafter Data Loading', () => {
 
     await expect(table.loadData()).rejects.toThrow('Network error');
   });
+
+  test('should abort an in-flight load when a new loadData() is started', async () => {
+    fetch.mockImplementation((url, opts) => new Promise((resolve, reject) => {
+      if (opts && opts.signal) {
+        opts.signal.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      }
+      // Never resolve — caller must abort to settle.
+    }));
+
+    table = new TableCrafter('#table-container', {
+      data: 'https://api.example.com/data'
+    });
+
+    const first = table.loadData();
+    const firstSignal = fetch.mock.calls[fetch.mock.calls.length - 1][1].signal;
+    expect(firstSignal.aborted).toBe(false);
+
+    // Start a second load — this should abort the first.
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1 }] });
+    const second = table.loadData();
+
+    await first; // AbortError is swallowed and resolves with current data.
+    expect(firstSignal.aborted).toBe(true);
+    await second;
+  });
 });
 
 describe('TableCrafter Rendering', () => {


### PR DESCRIPTION
## Summary

Fixes the long-standing red test on \`main\` and adds proper cancellation semantics to \`loadData()\`. Closes #71 (issue created with AC + TDD plan as part of this work).

The existing \`should load data from URL\` test in \`test/tablecrafter.test.js\` already asserted that \`fetch\` is invoked with an \`AbortSignal\`, but \`loadData()\` was calling \`fetch(this.dataUrl)\` with no second argument. There was also no way to cancel an in-flight request, so overlapping loads could resolve out of order and clobber newer state.

### Behaviour

Each \`loadData()\` call now:

- Aborts the previous controller (if any) before starting.
- Constructs a fresh \`AbortController\` and forwards its signal to \`fetch\` in both the SSR-hydration branch and the standard client-side branch.
- Treats \`AbortError\` from a superseded request as a benign no-op — no \`renderError\`, no rethrow.
- Only clears \`isLoading\` / \`_loadController\` when the in-flight load still owns the current controller, so a newer load's state survives.

## Test plan

- [x] \`should load data from URL\` (previously red) now passes.
- [x] New \`should abort an in-flight load when a new loadData() is started\` verifies the cancellation handshake end-to-end via a mocked \`fetch\` that resolves only when its signal aborts.
- [x] \`npm test\` — **63/63 passing** on this branch.

## Out of scope

- A public \`abort()\` method (phase 2).
- Retry-with-backoff coordination with the abort signal.