### PR TITLE
fix(loadData): pass AbortSignal to fetch and cancel in-flight loads (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tablecrafter",
-  "version": "1.6.0",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tablecrafter",
-      "version": "1.6.0",
+      "version": "1.6.5",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -330,6 +330,16 @@ class TableCrafter {
     this.isLoading = true;
     this.renderLoading();
 
+    // Cancel any in-flight loadData() before starting a new one so late
+    // resolutions can't overwrite newer state. Each call gets its own
+    // AbortController; the signal is passed to fetch().
+    if (this._loadController) {
+      this._loadController.abort();
+    }
+    const controller = new AbortController();
+    this._loadController = controller;
+    const signal = controller.signal;
+
     // If SSR mode is enabled and content exists, handle hydration logic
     if (this.container.dataset.ssr === "true") {
       // this.render(); // <-- REMOVED: Do not wipe server content yet!
@@ -338,7 +348,7 @@ class TableCrafter {
       this.data = this.processData(this.data);
       this.autoDiscoverColumns();
       this.detectFilterTypes();
-      
+
       this.container.dataset.ssr = "false";
       this.hydrateListeners(); // Attach listeners to existing DOM
       this.isLoading = false;
@@ -346,7 +356,7 @@ class TableCrafter {
     }
       if (this.dataUrl) {
          try {
-           const response = await fetch(this.dataUrl);
+           const response = await fetch(this.dataUrl, { signal });
            if (!response.ok) throw new Error(`HTTP ${response.status}`);
            const data = await response.json();
            this.data = this.processData(data);
@@ -355,6 +365,10 @@ class TableCrafter {
            this.container.dataset.ssr = "false";
            this.render();
          } catch (e) {
+           if (e && e.name === 'AbortError') {
+             // Superseded by a newer loadData() — benign, no UI surface.
+             return this.data;
+           }
            console.error('TableCrafter: Hydration failed', e);
            // Silent fail for hydration is okay, user sees SSR content
          }
@@ -365,16 +379,20 @@ class TableCrafter {
 
     // Standard Client-Side Load
     try {
-      const response = await fetch(this.dataUrl);
+      const response = await fetch(this.dataUrl, { signal });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
       this.data = this.processData(data); // Using processData for consistency
-      
+
       this.autoDiscoverColumns();
       this.render();
     } catch (error) {
+      if (error && error.name === 'AbortError') {
+        // Cancelled by a newer loadData() call — do not surface as an error.
+        return this.data;
+      }
       console.error('TableCrafter: Load failed', error);
       this.renderError('Unable to load data. The source may be unavailable.');
       throw error;

--- a/test/abort.test.js
+++ b/test/abort.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for AbortSignal handling in loadData() — see issue #71.
+ *
+ * Acceptance criteria covered here:
+ *   1. Each call to loadData() passes an AbortSignal to fetch.
+ *   2. A second loadData() call aborts the in-flight request from the first.
+ *   4. AbortError from the cancelled fetch does not surface as renderError.
+ *   5. SSR-hydration branch is also covered.
+ *
+ * AC #3 (existing "should load data from URL" test goes green) lives in
+ * test/tablecrafter.test.js and is verified by running the full suite.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+/**
+ * Build a TableCrafter without triggering the constructor's auto-load,
+ * then point it at a URL so loadData() can be invoked explicitly. This
+ * removes timing races between constructor-fired fetches and the test body.
+ */
+function makeTable(selector, dataUrl) {
+  const table = new TableCrafter(selector, { data: [] });
+  table.dataUrl = dataUrl;
+  return table;
+}
+
+describe('TableCrafter loadData() AbortSignal handling', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="table-container"></div>';
+  });
+
+  test('passes an AbortSignal on each fetch call', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 1 }]
+    });
+
+    const table = makeTable('#table-container', 'https://api.example.com/data');
+    await table.loadData();
+
+    expect(fetch).toHaveBeenCalled();
+    const [, options] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(options).toBeDefined();
+    expect(options.signal).toBeDefined();
+    expect(typeof options.signal.aborted).toBe('boolean');
+  });
+
+  test('aborts the in-flight signal when loadData() is called twice in quick succession', async () => {
+    const signals = [];
+
+    // First fetch: hangs forever unless aborted, then rejects with AbortError.
+    fetch.mockImplementationOnce((url, options) => {
+      signals.push(options.signal);
+      return new Promise((_, reject) => {
+        options.signal.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    // Second fetch: captures signal, resolves cleanly.
+    fetch.mockImplementationOnce((url, options) => {
+      signals.push(options.signal);
+      return Promise.resolve({
+        ok: true,
+        json: async () => [{ id: 2 }]
+      });
+    });
+
+    const table = makeTable('#table-container', 'https://api.example.com/data');
+
+    // Kick off the first load (do not await — it will only resolve once aborted).
+    const firstLoad = table.loadData();
+    // Allow a microtask so fetch is invoked and signal is captured.
+    await Promise.resolve();
+
+    // Second load — should abort the first.
+    await table.loadData();
+
+    expect(signals.length).toBe(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+
+    // First load resolves (silently) once aborted.
+    await firstLoad;
+  });
+
+  test('AbortError from a cancelled fetch does not call renderError', async () => {
+    fetch.mockImplementationOnce((url, options) => {
+      return new Promise((_, reject) => {
+        options.signal.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    fetch.mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: async () => [{ id: 1 }]
+    }));
+
+    const table = makeTable('#table-container', 'https://api.example.com/data');
+    const renderErrorSpy = jest.spyOn(table, 'renderError');
+
+    const firstLoad = table.loadData();
+    await Promise.resolve();
+    await table.loadData();
+    await firstLoad;
+
+    expect(renderErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test('SSR hydration branch also passes an AbortSignal to fetch', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 99 }]
+    });
+
+    const container = document.getElementById('table-container');
+    container.dataset.ssr = 'true';
+
+    // Build with empty data + SSR flag so loadData() falls into the SSR
+    // branch's fetch path (no embedded data => fetch fallback).
+    const table = makeTable('#table-container', 'https://api.example.com/data');
+    container.dataset.ssr = 'true'; // re-assert in case constructor cleared it
+    table.data = [];
+
+    await table.loadData();
+
+    expect(fetch).toHaveBeenCalled();
+    const [, options] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(options).toBeDefined();
+    expect(options.signal).toBeDefined();
+    expect(typeof options.signal.aborted).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Closes #71.

## Summary
- `loadData()` now constructs an `AbortController` per call and passes its `signal` into `fetch(url, { signal })`.
- If a new `loadData()` starts while a previous one is in flight, the previous controller is aborted first, so a late-resolving stale response can no longer overwrite newer state.
- An `AbortError` from a cancelled fetch is treated as a benign no-op — it is not surfaced via `renderError` and does not throw out of `loadData()`.
- Both the standard client-side path and the SSR-hydration fetch fallback share this behaviour.

## Acceptance Criteria coverage (#71)
1. ✅ Each `loadData()` constructs an `AbortController` and passes its signal to `fetch`.
2. ✅ A new call aborts the prior controller before issuing the next fetch.
3. ✅ The pre-existing `should load data from URL` test in `test/tablecrafter.test.js` (already asserting `signal: expect.anything()`) is now green.
4. ✅ `AbortError` is silently swallowed inside `loadData()` and does not call `renderError`.
5. ✅ SSR-hydration branch (`container.dataset.ssr === \"true\"`) is also covered.

## TDD
New file: `test/abort.test.js` with four cases — signal presence, double-call abort, AbortError → no `renderError`, SSR fetch path. All four were red before the implementation change, all four go green after. Full suite (`npx jest`) is green: 9 suites / 66 tests.

## Out of scope (per issue)
- Public `abort()` method.
- Retry-with-backoff coordination with the abort signal.

## Notes
- `package-lock.json` is bumped from `1.6.0` to `1.6.5` to match `package.json` after `npm install`. No dep tree changes.

🤖 Automated PR from a scheduled fix-issues run.