### PR TITLE
fix(loadData): pass AbortSignal to fetch and cancel in-flight loads (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tablecrafter",
-  "version": "1.6.0",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tablecrafter",
-      "version": "1.6.0",
+      "version": "1.6.5",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -327,6 +327,17 @@ class TableCrafter {
    * Load data from URL
    */
   async loadData() {
+    // Cancel any in-flight load before starting a new one so late resolutions
+    // can't overwrite newer state.
+    if (this._loadAbortController) {
+      this._loadAbortController.abort();
+    }
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    this._loadAbortController = controller;
+    const signal = controller ? controller.signal : undefined;
+    const isAborted = () => controller && controller.signal.aborted;
+    const isAbortError = (err) => err && (err.name === 'AbortError' || isAborted());
+
     this.isLoading = true;
     this.renderLoading();
 
@@ -338,7 +349,7 @@ class TableCrafter {
       this.data = this.processData(this.data);
       this.autoDiscoverColumns();
       this.detectFilterTypes();
-      
+
       this.container.dataset.ssr = "false";
       this.hydrateListeners(); // Attach listeners to existing DOM
       this.isLoading = false;
@@ -346,17 +357,24 @@ class TableCrafter {
     }
       if (this.dataUrl) {
          try {
-           const response = await fetch(this.dataUrl);
+           const response = await fetch(this.dataUrl, { signal });
+           if (isAborted()) return;
            if (!response.ok) throw new Error(`HTTP ${response.status}`);
            const data = await response.json();
+           if (isAborted()) return;
            this.data = this.processData(data);
            this.autoDiscoverColumns();
            this.detectFilterTypes();
            this.container.dataset.ssr = "false";
            this.render();
          } catch (e) {
+           if (isAbortError(e)) return;
            console.error('TableCrafter: Hydration failed', e);
            // Silent fail for hydration is okay, user sees SSR content
+         } finally {
+           if (this._loadAbortController === controller) {
+             this._loadAbortController = null;
+           }
          }
       }
       this.isLoading = false;
@@ -365,20 +383,29 @@ class TableCrafter {
 
     // Standard Client-Side Load
     try {
-      const response = await fetch(this.dataUrl);
+      const response = await fetch(this.dataUrl, { signal });
+      if (isAborted()) return;
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
+      if (isAborted()) return;
       this.data = this.processData(data); // Using processData for consistency
-      
+
       this.autoDiscoverColumns();
       this.render();
     } catch (error) {
+      if (isAbortError(error)) {
+        // Cancelled load — benign no-op, newer load (or caller) handles state.
+        return;
+      }
       console.error('TableCrafter: Load failed', error);
       this.renderError('Unable to load data. The source may be unavailable.');
       throw error;
     } finally {
+      if (this._loadAbortController === controller) {
+        this._loadAbortController = null;
+      }
       this.isLoading = false;
     }
   }

--- a/test/tablecrafter.test.js
+++ b/test/tablecrafter.test.js
@@ -115,6 +115,62 @@ describe('TableCrafter Data Loading', () => {
 
     await expect(table.loadData()).rejects.toThrow('Network error');
   });
+
+  test('should abort in-flight loadData when a new one starts', async () => {
+    // Construct without a URL so we control fetch call ordering ourselves.
+    table = new TableCrafter('#table-container', { data: [] });
+    table.dataUrl = 'https://api.example.com/data';
+
+    let firstSignal;
+    let secondSignal;
+    let resolveFirst;
+
+    fetch
+      .mockImplementationOnce((url, opts) => {
+        firstSignal = opts && opts.signal;
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      })
+      .mockImplementationOnce((url, opts) => {
+        secondSignal = opts && opts.signal;
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 99 }]
+        });
+      });
+
+    const first = table.loadData();
+    const second = table.loadData();
+
+    expect(firstSignal).toBeDefined();
+    expect(firstSignal.aborted).toBe(true);
+    expect(secondSignal).toBeDefined();
+    expect(secondSignal.aborted).toBe(false);
+
+    // Resolve the first (now-stale) fetch — its late resolution should not
+    // overwrite the newer load's data.
+    resolveFirst({ ok: true, json: async () => [{ id: 1 }] });
+
+    await second;
+    await first.catch(() => {});
+
+    expect(table.getData()).toEqual([{ id: 99 }]);
+  });
+
+  test('should not surface AbortError from a cancelled load as renderError', async () => {
+    table = new TableCrafter('#table-container', { data: [] });
+    table.dataUrl = 'https://api.example.com/data';
+
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    fetch.mockRejectedValueOnce(abortErr);
+
+    const renderErrorSpy = jest.spyOn(table, 'renderError');
+
+    await expect(table.loadData()).resolves.toBeUndefined();
+    expect(renderErrorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('TableCrafter Rendering', () => {


### PR DESCRIPTION
## Summary

Fixes #71. `loadData()` now wires every `fetch` call through a per-call `AbortController` and aborts any previous in-flight load before starting a new one, so late resolutions cannot overwrite newer state. AbortError (or any error after the controller has been aborted) is treated as a benign no-op and does not surface as `renderError`. The SSR-hydration branch goes through the same controller.

## What changed

- `src/tablecrafter.js` — `loadData()` constructs an `AbortController` per call, stores it on `this._loadAbortController`, and aborts the previous one if present. Both the SSR-hydration `fetch` and the standard client-side `fetch` now receive `{ signal }`. Aborted/late results bail out early via an `isAborted()` guard, and `isAbortError()` swallows AbortError (or any error after a known abort) instead of triggering `renderError`.
- `test/tablecrafter.test.js`:
  - The pre-existing `should load data from URL` test (which already asserted `signal: expect.anything()`) now passes.
  - Added `should abort in-flight loadData when a new one starts`: kicks off two back-to-back `loadData()` calls, asserts the first call's `signal.aborted === true` and the second's `signal.aborted === false`, then resolves the (stale) first fetch and verifies the second load's data wins.
  - Added `should not surface AbortError from a cancelled load as renderError`: rejects fetch with an `AbortError`, asserts `renderError` is never called and `loadData()` resolves cleanly.

## Acceptance criteria

- [x] Each `loadData()` call constructs an `AbortController` and passes its `signal` to `fetch`.
- [x] A new `loadData()` call aborts the previous controller before fetching.
- [x] The existing `should load data from URL` test goes green without changes.
- [x] `AbortError` from a cancelled request does not surface as `renderError`.
- [x] SSR-hydration branch is also covered (same controller, same `signal`).

## Out of scope (per the issue)

- Public `abort()` method (phase 2).
- Retry-with-backoff coordination with the abort signal.

## Test plan

- [x] `npx jest test/tablecrafter.test.js` — 19/19 pass (the formerly-red `should load data from URL` is now green; two new tests added for abort behaviour).
- [x] `npx jest` — full suite 64/64 pass across 8 test files (no regressions in hydration, pagination, filtering, error handling, accessibility, csv-export, skeleton).