### PR TITLE
fix(api): pass AbortSignal to fetch and cancel overlapping loadData calls

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -330,6 +330,13 @@ class TableCrafter {
     this.isLoading = true;
     this.renderLoading();
 
+    if (this._loadController) {
+      this._loadController.abort();
+    }
+    const controller = new AbortController();
+    this._loadController = controller;
+    const signal = controller.signal;
+
     // If SSR mode is enabled and content exists, handle hydration logic
     if (this.container.dataset.ssr === "true") {
       // this.render(); // <-- REMOVED: Do not wipe server content yet!
@@ -338,7 +345,7 @@ class TableCrafter {
       this.data = this.processData(this.data);
       this.autoDiscoverColumns();
       this.detectFilterTypes();
-      
+
       this.container.dataset.ssr = "false";
       this.hydrateListeners(); // Attach listeners to existing DOM
       this.isLoading = false;
@@ -346,7 +353,7 @@ class TableCrafter {
     }
       if (this.dataUrl) {
          try {
-           const response = await fetch(this.dataUrl);
+           const response = await fetch(this.dataUrl, { signal });
            if (!response.ok) throw new Error(`HTTP ${response.status}`);
            const data = await response.json();
            this.data = this.processData(data);
@@ -355,6 +362,10 @@ class TableCrafter {
            this.container.dataset.ssr = "false";
            this.render();
          } catch (e) {
+           if (e && e.name === 'AbortError') {
+             // Superseded by a newer loadData() — leave SSR content alone.
+             return this.data;
+           }
            console.error('TableCrafter: Hydration failed', e);
            // Silent fail for hydration is okay, user sees SSR content
          }
@@ -365,16 +376,20 @@ class TableCrafter {
 
     // Standard Client-Side Load
     try {
-      const response = await fetch(this.dataUrl);
+      const response = await fetch(this.dataUrl, { signal });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
       this.data = this.processData(data); // Using processData for consistency
-      
+
       this.autoDiscoverColumns();
       this.render();
     } catch (error) {
+      if (error && error.name === 'AbortError') {
+        // Cancelled by a newer loadData() call — benign, do not surface.
+        return this.data;
+      }
       console.error('TableCrafter: Load failed', error);
       this.renderError('Unable to load data. The source may be unavailable.');
       throw error;

--- a/test/tablecrafter.test.js
+++ b/test/tablecrafter.test.js
@@ -115,6 +115,73 @@ describe('TableCrafter Data Loading', () => {
 
     await expect(table.loadData()).rejects.toThrow('Network error');
   });
+
+  test('should abort the previous in-flight loadData when a new one starts', async () => {
+    const mockData = [{ id: 1, name: 'A' }];
+    const capturedSignals = [];
+
+    fetch.mockImplementation((url, options = {}) => {
+      capturedSignals.push(options.signal);
+      return new Promise((resolve, reject) => {
+        if (options.signal) {
+          options.signal.addEventListener('abort', () => {
+            const err = new Error('Aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+        setTimeout(() => resolve({ ok: true, json: async () => mockData }), 50);
+      });
+    });
+
+    table = new TableCrafter('#table-container', {
+      data: 'https://api.example.com/data'
+    });
+
+    const first = table.loadData();
+    first.catch(() => {});
+    const second = table.loadData();
+    await second;
+
+    expect(capturedSignals.length).toBeGreaterThanOrEqual(2);
+    const firstSignal = capturedSignals[capturedSignals.length - 2];
+    const secondSignal = capturedSignals[capturedSignals.length - 1];
+    expect(firstSignal).toBeDefined();
+    expect(firstSignal.aborted).toBe(true);
+    expect(secondSignal.aborted).toBe(false);
+  });
+
+  test('should not surface AbortError as a render error', async () => {
+    const renderErrorSpy = jest.fn();
+
+    fetch.mockImplementation((url, options = {}) => {
+      return new Promise((_resolve, reject) => {
+        if (options.signal) {
+          options.signal.addEventListener('abort', () => {
+            const err = new Error('Aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    });
+
+    table = new TableCrafter('#table-container', {
+      data: 'https://api.example.com/data'
+    });
+    table.renderError = renderErrorSpy;
+
+    const first = table.loadData();
+    first.catch(() => {});
+    const second = table.loadData().catch(() => {});
+
+    // Force-abort the second call so the test does not hang
+    if (table._loadController) table._loadController.abort();
+    await first.catch(() => {});
+    await second;
+
+    expect(renderErrorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('TableCrafter Rendering', () => {


### PR DESCRIPTION
## Summary
- `loadData()` constructs an `AbortController` per call, aborts any prior in-flight controller, and forwards the signal to `fetch` in both the SSR-hydration branch and the standard client-side branch.
- `AbortError` is treated as a benign no-op (no `renderError`, no rethrow) so a superseded load does not look like a real failure.

## Acceptance criteria (from #71)
- [x] Each call constructs an `AbortController` and passes its `signal` to `fetch`.
- [x] A new `loadData()` call aborts the prior controller before issuing the new fetch.
- [x] The pre-existing `should load data from URL` test goes green.
- [x] `AbortError` from a cancelled request does not surface as `renderError`.
- [x] SSR-hydration branch (`container.dataset.ssr === \"true\"`) is also covered.

## Tests
- Pre-existing red test in `test/tablecrafter.test.js` (`should load data from URL`) is now green.
- New test: `should abort the previous in-flight loadData when a new one starts` — asserts the first call's signal flips to `aborted: true` after a second call.
- New test: `should not surface AbortError as a render error` — spies `renderError` and asserts it is not invoked when the controller is aborted.
- Full suite: 64/64 passing locally.

Closes #71