### PR TITLE
feat(api): row-level CRUD methods (addRow / updateRow / removeRow) with lifecycle callbacks

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2520,6 +2520,99 @@ class TableCrafter {
   }
 
   /**
+   * Append a row, fire the onAdd lifecycle, re-render.
+   * Delegates to createEntry so API-backed tables go through the configured
+   * endpoint; falls back to a plain push when no API is configured.
+   */
+  async addRow(rowData) {
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('create')) {
+      throw new Error('TableCrafter: permission denied for create');
+    }
+
+    const result = await this.createEntry(rowData);
+    const row = result || rowData;
+
+    // Reconcile in case createEntry was stubbed and did not mutate data.
+    if (this.data[this.data.length - 1] !== row) {
+      this.data.push(row);
+    }
+    const index = this.data.length - 1;
+
+    this.render();
+
+    if (typeof this.config.onAdd === 'function') {
+      this.config.onAdd({ row, index });
+    }
+    return row;
+  }
+
+  /**
+   * Merge new fields into an existing row, fire onUpdate, re-render.
+   */
+  async updateRow(index, rowData) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`TableCrafter: updateRow index ${index} out of range`);
+    }
+
+    const previous = { ...this.data[index] };
+
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('edit', previous)) {
+      throw new Error('TableCrafter: permission denied for edit');
+    }
+
+    const result = await this.updateEntry(index, rowData);
+    const row = result || this.data[index];
+
+    if (this.data[index] !== row) {
+      this.data[index] = row;
+    }
+
+    this.render();
+
+    if (typeof this.config.onUpdate === 'function') {
+      this.config.onUpdate({ row, index, previous });
+    }
+    return row;
+  }
+
+  /**
+   * Remove a row, fire onDelete, re-render.
+   * options.confirm === true triggers window.confirm; cancellation is a no-op
+   * that resolves false without API call, callback, or re-render.
+   */
+  async removeRow(index, options = {}) {
+    if (!Number.isInteger(index) || index < 0 || index >= this.data.length) {
+      throw new RangeError(`TableCrafter: removeRow index ${index} out of range`);
+    }
+
+    const row = this.data[index];
+
+    if (this.config.permissions && this.config.permissions.enabled && !this.hasPermission('delete', row)) {
+      throw new Error('TableCrafter: permission denied for delete');
+    }
+
+    if (options && options.confirm === true) {
+      if (!window.confirm('Delete this row?')) {
+        return false;
+      }
+    }
+
+    const before = this.data.length;
+    await this.deleteEntry(index);
+
+    if (this.data.length === before && this.data[index] === row) {
+      this.data.splice(index, 1);
+    }
+
+    this.render();
+
+    if (typeof this.config.onDelete === 'function') {
+      this.config.onDelete({ row, index });
+    }
+    return true;
+  }
+
+  /**
    * Create new entry via API
    */
   async createEntry(entryData) {

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -1,0 +1,245 @@
+/**
+ * Row-level CRUD method tests (issue #66)
+ * Covers addRow / updateRow / removeRow with lifecycle callbacks,
+ * API delegation, render side-effects, and permission gating.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+describe('TableCrafter Row CRUD', () => {
+  let container;
+  let table;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="table-container"></div>';
+    container = document.getElementById('table-container');
+  });
+
+  afterEach(() => {
+    if (table && typeof table.destroy === 'function') {
+      table.destroy();
+    }
+    table = null;
+  });
+
+  // ------------------------------------------------------------------
+  // addRow
+  // ------------------------------------------------------------------
+  describe('addRow', () => {
+    test('returns a promise resolving to the appended row, mutates data, fires onAdd, re-renders', async () => {
+      const onAdd = jest.fn();
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1, name: 'A' }],
+        columns: [{ field: 'id', label: 'ID' }, { field: 'name', label: 'Name' }],
+        onAdd
+      });
+      const renderSpy = jest.spyOn(table, 'render');
+
+      const result = await table.addRow({ id: 2, name: 'B' });
+
+      expect(result).toEqual({ id: 2, name: 'B' });
+      expect(table.getData()).toHaveLength(2);
+      expect(table.getData()[1]).toEqual({ id: 2, name: 'B' });
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+      expect(onAdd).toHaveBeenCalledTimes(1);
+      expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
+        row: { id: 2, name: 'B' },
+        index: 1
+      }));
+    });
+
+    test('delegates to createEntry when api.baseUrl is configured', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [],
+        columns: [{ field: 'id', label: 'ID' }],
+        api: { baseUrl: 'https://api.example.com' }
+      });
+      const createSpy = jest
+        .spyOn(table, 'createEntry')
+        .mockResolvedValue({ id: 99, name: 'srv' });
+
+      const result = await table.addRow({ name: 'srv' });
+
+      expect(createSpy).toHaveBeenCalledWith({ name: 'srv' });
+      expect(result).toEqual({ id: 99, name: 'srv' });
+      expect(table.getData()).toEqual([{ id: 99, name: 'srv' }]);
+    });
+
+    test('rejects with permission error when create is disallowed', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [],
+        columns: [{ field: 'id', label: 'ID' }],
+        permissions: { enabled: true, create: ['admin'], view: ['*'], edit: ['*'], delete: ['*'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.addRow({ id: 1 })).rejects.toThrow(/permission/i);
+      expect(table.getData()).toHaveLength(0);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // updateRow
+  // ------------------------------------------------------------------
+  describe('updateRow', () => {
+    test('merges fields, fires onUpdate with previous, re-renders', async () => {
+      const onUpdate = jest.fn();
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1, name: 'A', email: 'a@x' }],
+        columns: [{ field: 'id', label: 'ID' }, { field: 'name', label: 'Name' }],
+        onUpdate
+      });
+      const renderSpy = jest.spyOn(table, 'render');
+
+      const result = await table.updateRow(0, { name: 'AA' });
+
+      expect(result).toEqual({ id: 1, name: 'AA', email: 'a@x' });
+      expect(table.getData()[0]).toEqual({ id: 1, name: 'AA', email: 'a@x' });
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
+        row: { id: 1, name: 'AA', email: 'a@x' },
+        index: 0,
+        previous: { id: 1, name: 'A', email: 'a@x' }
+      }));
+    });
+
+    test('delegates to updateEntry when api.baseUrl is configured', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1, name: 'A' }],
+        columns: [{ field: 'id', label: 'ID' }],
+        api: { baseUrl: 'https://api.example.com' }
+      });
+      const updateSpy = jest
+        .spyOn(table, 'updateEntry')
+        .mockResolvedValue({ id: 1, name: 'B' });
+
+      await table.updateRow(0, { name: 'B' });
+
+      expect(updateSpy).toHaveBeenCalledWith(0, { name: 'B' });
+    });
+
+    test('rejects with RangeError on out-of-range index', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }]
+      });
+
+      await expect(table.updateRow(5, { id: 2 })).rejects.toBeInstanceOf(RangeError);
+      await expect(table.updateRow(-1, { id: 2 })).rejects.toBeInstanceOf(RangeError);
+    });
+
+    test('rejects with permission error when edit is disallowed', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1, name: 'A' }],
+        columns: [{ field: 'id', label: 'ID' }],
+        permissions: { enabled: true, edit: ['admin'], view: ['*'], create: ['*'], delete: ['*'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.updateRow(0, { name: 'B' })).rejects.toThrow(/permission/i);
+      expect(table.getData()[0]).toEqual({ id: 1, name: 'A' });
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // removeRow
+  // ------------------------------------------------------------------
+  describe('removeRow', () => {
+    test('removes entry, fires onDelete, re-renders, resolves true', async () => {
+      const onDelete = jest.fn();
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }],
+        columns: [{ field: 'id', label: 'ID' }],
+        onDelete
+      });
+      const renderSpy = jest.spyOn(table, 'render');
+
+      const result = await table.removeRow(0);
+
+      expect(result).toBe(true);
+      expect(table.getData()).toEqual([{ id: 2, name: 'B' }]);
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+      expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({
+        row: { id: 1, name: 'A' },
+        index: 0
+      }));
+    });
+
+    test('honours { confirm: true } accept path', async () => {
+      const onDelete = jest.fn();
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }],
+        onDelete
+      });
+
+      const result = await table.removeRow(0, { confirm: true });
+
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(result).toBe(true);
+      expect(table.getData()).toHaveLength(0);
+      expect(onDelete).toHaveBeenCalledTimes(1);
+
+      confirmSpy.mockRestore();
+    });
+
+    test('honours { confirm: true } cancel path — no callback, no API, no render, resolves false', async () => {
+      const onDelete = jest.fn();
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }],
+        onDelete,
+        api: { baseUrl: 'https://api.example.com' }
+      });
+      const deleteSpy = jest.spyOn(table, 'deleteEntry');
+      const renderSpy = jest.spyOn(table, 'render');
+
+      const result = await table.removeRow(0, { confirm: true });
+
+      expect(result).toBe(false);
+      expect(table.getData()).toEqual([{ id: 1 }]);
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(renderSpy).not.toHaveBeenCalled();
+
+      confirmSpy.mockRestore();
+    });
+
+    test('delegates to deleteEntry when api.baseUrl is configured', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }],
+        api: { baseUrl: 'https://api.example.com' }
+      });
+      const deleteSpy = jest.spyOn(table, 'deleteEntry').mockResolvedValue(true);
+
+      await table.removeRow(0);
+
+      expect(deleteSpy).toHaveBeenCalledWith(0);
+    });
+
+    test('rejects with RangeError on out-of-range index', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }]
+      });
+
+      await expect(table.removeRow(5)).rejects.toBeInstanceOf(RangeError);
+      await expect(table.removeRow(-1)).rejects.toBeInstanceOf(RangeError);
+    });
+
+    test('rejects with permission error when delete is disallowed', async () => {
+      table = new TableCrafter('#table-container', {
+        data: [{ id: 1 }],
+        columns: [{ field: 'id', label: 'ID' }],
+        permissions: { enabled: true, delete: ['admin'], view: ['*'], edit: ['*'], create: ['*'] }
+      });
+      table.setCurrentUser({ id: 1, roles: ['viewer'] });
+
+      await expect(table.removeRow(0)).rejects.toThrow(/permission/i);
+      expect(table.getData()).toEqual([{ id: 1 }]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds public `addRow`, `updateRow`, `removeRow` to TableCrafter, delegating to the existing `createEntry` / `updateEntry` / `deleteEntry` helpers.
- Fires the matching `onAdd` / `onUpdate` / `onDelete` lifecycle callbacks with the payload shape specified in #66.
- Re-renders on every successful mutation.
- Rejects with `RangeError` for bad indices on `updateRow` / `removeRow`.
- Rejects with a permission error when `permissions.enabled` is on and the user lacks the relevant role.

## Acceptance criteria (from #66)
- [x] `addRow(rowData)` → Promise; appends, calls createEntry under API, fires `onAdd({ row, index })`, re-renders.
- [x] `updateRow(index, rowData)` → Promise; merges fields, fires `onUpdate({ row, index, previous })`, re-renders, RangeError on bad index.
- [x] `removeRow(index, options?)` → Promise; honours `{ confirm: true }` accept and cancel paths; fires `onDelete({ row, index })`, RangeError on bad index.
- [x] Permission errors when `permissions.enabled` and user lacks `create` / `edit` / `delete`.
- [x] Existing public API unchanged (`createEntry`, `updateEntry`, `deleteEntry`, `bulkDelete`, `onEdit`).
- [x] README CRUD signatures still match.

## Tests
- New file `test/crud.test.js`: 13 tests covering each AC, including API-delegation spies, confirm accept/cancel paths, RangeError, and permission rejections.
- Local: 74/75 pass. The one remaining red is the pre-existing failure tracked in #71 (`should load data from URL`) — fix is on PR #75; unrelated to this branch.

Closes #66
Closes #64
