### PR TITLE
feat(validation): add url / oneOf / notOneOf built-in rules

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -59,6 +59,9 @@ class TableCrafter {
         messages: {
           required: 'This field is required',
           email: 'Please enter a valid email address',
+          url: 'Please enter a valid URL',
+          oneOf: 'Value must be one of {allowed}',
+          notOneOf: 'Value is not allowed',
           minLength: 'Minimum length is {min} characters',
           maxLength: 'Maximum length is {max} characters',
           min: 'Minimum value is {min}',
@@ -3264,9 +3267,13 @@ class TableCrafter {
       errors.push(this.getValidationMessage('required', rules));
     }
 
-    // Skip other validations if empty and not required
-    if (!rules.required && (value === null || value === undefined || value === '')) {
-      return { isValid: true };
+    // Skip format-style validations when value is empty.
+    // Required errors (collected above) are returned as-is; non-required+empty resolves clean.
+    if (value === null || value === undefined || value === '') {
+      return {
+        isValid: errors.length === 0,
+        errors: errors
+      };
     }
 
     // Email validation
@@ -3297,6 +3304,22 @@ class TableCrafter {
       if (!isNaN(numValue) && numValue > rules.max) {
         errors.push(this.getValidationMessage('max', rules));
       }
+    }
+
+    // URL validation
+    if (rules.url) {
+      const urlRegex = /^https?:\/\/[^\s.]+\.[^\s]+$/;
+      if (!urlRegex.test(value)) {
+        errors.push(this.getValidationMessage('url', rules));
+      }
+    }
+
+    // oneOf / notOneOf membership validation
+    if (Array.isArray(rules.oneOf) && !rules.oneOf.includes(value)) {
+      errors.push(this.getValidationMessage('oneOf', rules));
+    }
+    if (Array.isArray(rules.notOneOf) && rules.notOneOf.includes(value)) {
+      errors.push(this.getValidationMessage('notOneOf', rules));
     }
 
     // Pattern validation
@@ -3336,6 +3359,8 @@ class TableCrafter {
     if (rules.maxLength) message = message.replace('{max}', rules.maxLength);
     if (rules.min !== undefined) message = message.replace('{min}', rules.min);
     if (rules.max !== undefined) message = message.replace('{max}', rules.max);
+    if (Array.isArray(rules.oneOf)) message = message.replace('{allowed}', rules.oneOf.join(', '));
+    if (Array.isArray(rules.notOneOf)) message = message.replace('{disallowed}', rules.notOneOf.join(', '));
 
     return message;
   }

--- a/test/validation-builtin-rules.test.js
+++ b/test/validation-builtin-rules.test.js
@@ -1,0 +1,122 @@
+/**
+ * Built-in validation rules: url / oneOf / notOneOf
+ * Slice of issue #41 (built-in rule library expansion).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(rules) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'value', label: 'Value' }],
+    validation: {
+      enabled: true,
+      showErrors: true,
+      validateOnEdit: true,
+      validateOnSubmit: true,
+      rules: { value: rules },
+      messages: {
+        required: 'This field is required',
+        email: 'Please enter a valid email address',
+        url: 'Please enter a valid URL',
+        oneOf: 'Value must be one of {allowed}',
+        notOneOf: 'Value is not allowed',
+        minLength: 'Minimum length is {min} characters',
+        maxLength: 'Maximum length is {max} characters',
+        min: 'Minimum value is {min}',
+        max: 'Maximum value is {max}',
+        pattern: 'Please enter a valid format',
+        custom: 'Validation failed'
+      }
+    }
+  });
+}
+
+describe('Validation: built-in rules (url / oneOf / notOneOf)', () => {
+  describe('url', () => {
+    test('accepts well-formed http(s) URLs', () => {
+      const t = makeTable({ url: true });
+      expect(t.validateField('value', 'https://example.com').isValid).toBe(true);
+      expect(t.validateField('value', 'http://example.com/path?q=1#x').isValid).toBe(true);
+      expect(t.validateField('value', 'https://sub.example.co.uk:8080/a/b').isValid).toBe(true);
+    });
+
+    test('rejects malformed URLs with the configured message', () => {
+      const t = makeTable({ url: true });
+      const r = t.validateField('value', 'not a url');
+      expect(r.isValid).toBe(false);
+      expect(r.errors[0]).toMatch(/url/i);
+
+      expect(t.validateField('value', 'example.com').isValid).toBe(false);
+      expect(t.validateField('value', 'ftp://example.com').isValid).toBe(false);
+      expect(t.validateField('value', 'http://').isValid).toBe(false);
+    });
+
+    test('honours custom message override', () => {
+      const t = makeTable({ url: true, message: 'must be a link' });
+      const r = t.validateField('value', 'nope');
+      expect(r.errors[0]).toBe('must be a link');
+    });
+
+    test('skips validation on empty value when not required', () => {
+      const t = makeTable({ url: true });
+      expect(t.validateField('value', '').isValid).toBe(true);
+      expect(t.validateField('value', null).isValid).toBe(true);
+    });
+  });
+
+  describe('oneOf', () => {
+    test('accepts values present in the allowed list', () => {
+      const t = makeTable({ oneOf: ['draft', 'published', 'archived'] });
+      expect(t.validateField('value', 'draft').isValid).toBe(true);
+      expect(t.validateField('value', 'published').isValid).toBe(true);
+    });
+
+    test('rejects values outside the allowed list', () => {
+      const t = makeTable({ oneOf: ['draft', 'published'] });
+      const r = t.validateField('value', 'pending');
+      expect(r.isValid).toBe(false);
+      expect(r.errors[0]).toMatch(/draft|published|allowed/i);
+    });
+
+    test('handles numeric and mixed-type lists', () => {
+      const t = makeTable({ oneOf: [1, 2, 3] });
+      expect(t.validateField('value', 2).isValid).toBe(true);
+      expect(t.validateField('value', 4).isValid).toBe(false);
+    });
+  });
+
+  describe('notOneOf', () => {
+    test('accepts values not in the disallowed list', () => {
+      const t = makeTable({ notOneOf: ['admin', 'root'] });
+      expect(t.validateField('value', 'editor').isValid).toBe(true);
+    });
+
+    test('rejects values present in the disallowed list', () => {
+      const t = makeTable({ notOneOf: ['admin', 'root'] });
+      const r = t.validateField('value', 'admin');
+      expect(r.isValid).toBe(false);
+      expect(r.errors[0]).toMatch(/admin|not allowed|reserved/i);
+    });
+  });
+
+  describe('combined with required and other rules', () => {
+    test('required + url: empty fails on required, malformed fails on url', () => {
+      const t = makeTable({ required: true, url: true });
+      const e = t.validateField('value', '');
+      expect(e.isValid).toBe(false);
+      expect(e.errors[0]).toMatch(/required/i);
+
+      const u = t.validateField('value', 'nope');
+      expect(u.isValid).toBe(false);
+      expect(u.errors[0]).toMatch(/url/i);
+    });
+
+    test('oneOf + required: empty fails on required only', () => {
+      const t = makeTable({ required: true, oneOf: ['a', 'b'] });
+      const r = t.validateField('value', '');
+      expect(r.errors).toHaveLength(1);
+      expect(r.errors[0]).toMatch(/required/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Slice of issue #41 — built-in rule library expansion. Adds three new validators to `validateField()`:

- `url` — matches `https?://host.tld[/...]`
- `oneOf: [...]` — membership in an allowed list
- `notOneOf: [...]` — exclusion from a disallowed list

Default messages and `{allowed}` / `{disallowed}` substitution tokens are wired through `getValidationMessage()`.

Also tightens the empty-value early-return so format rules are skipped on empty input regardless of whether `required` is set. This eliminates a latent double-error case (e.g. `{ required: true, email: true }` on an empty value previously surfaced both errors instead of just the required one).

## Tests
New file `test/validation-builtin-rules.test.js` — 11 cases:
- `url`: well-formed URLs accepted (http, https, with port + path + query + fragment); malformed rejected (no scheme, ftp, scheme-only); custom message override; empty value bypass.
- `oneOf`: positive list, negative list, numeric list.
- `notOneOf`: positive and negative paths.
- Combinations with `required`.

Full suite: 72/73 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated to this branch.

## Scope
Partial fix for #41 — addresses item 3 (built-in rule library expansion) for `url` / `oneOf` / `notOneOf`. The remaining items in #41 (async validation, rowRules, phone / unique / date.min/max, a11y aria-invalid, `validate()` / `getErrors()` / `clearErrors()` API) remain open and can be picked up in follow-up PRs.

Refs #41