### PR TITLE
feat(i18n): add t() translation helper with locale fallback (foundation for #40)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -107,6 +107,14 @@ class TableCrafter {
         headers: {},
         authentication: null
       },
+      // i18n configuration (foundation only — pluralisation, RTL,
+      // formatNumber/Date are tracked in follow-ups for #40)
+      i18n: {
+        locale: null,            // null = resolve from document at construction time
+        fallbackLocale: 'en',
+        messages: {},
+        formats: {}
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -2705,6 +2713,49 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Translate a message key against the configured i18n catalogue.
+   * Lookup order: active locale → fallback locale → key itself (with one warn).
+   * Variable substitution: {name} placeholders read from `vars`. Missing vars
+   * leave the placeholder intact so the bug is visible rather than silently empty.
+   */
+  t(key, vars) {
+    const i18n = (this.config && this.config.i18n) || {};
+    const messages = i18n.messages || {};
+    const locale = this._resolveLocale();
+    const fallback = i18n.fallbackLocale || 'en';
+
+    let template;
+    if (messages[locale] && Object.prototype.hasOwnProperty.call(messages[locale], key)) {
+      template = messages[locale][key];
+    } else if (messages[fallback] && Object.prototype.hasOwnProperty.call(messages[fallback], key)) {
+      template = messages[fallback][key];
+    } else {
+      if (!this._missingI18nKeys) this._missingI18nKeys = new Set();
+      if (!this._missingI18nKeys.has(key)) {
+        this._missingI18nKeys.add(key);
+        console.warn(`TableCrafter i18n: missing translation for "${key}"`);
+      }
+      template = key;
+    }
+
+    if (typeof template !== 'string' || !vars) {
+      return template;
+    }
+    return template.replace(/\{(\w+)\}/g, (m, name) => {
+      return Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : m;
+    });
+  }
+
+  _resolveLocale() {
+    const i18n = (this.config && this.config.i18n) || {};
+    if (i18n.locale) return i18n.locale;
+    if (typeof document !== 'undefined' && document.documentElement && document.documentElement.lang) {
+      return document.documentElement.lang;
+    }
+    return 'en';
+  }
 
   /**
    * Set current user context

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,0 +1,98 @@
+/**
+ * i18n foundation: t(key, vars?) helper, locale resolution, fallback, warn-once.
+ * Slice of issue #40 (translation function only — pluralisation, formatNumber,
+ * formatDate, RTL handling, setLocale and built-in locale packs are tracked
+ * for follow-up PRs).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(i18n) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id', label: 'ID' }],
+    i18n
+  });
+}
+
+describe('i18n: t(key, vars?) helper', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('returns the active-locale string when the key exists', () => {
+    const table = makeTable({
+      locale: 'es',
+      messages: { es: { 'toolbar.search': 'Buscar' } }
+    });
+    expect(table.t('toolbar.search')).toBe('Buscar');
+  });
+
+  test('falls through to fallbackLocale when the key is missing in active locale', () => {
+    const table = makeTable({
+      locale: 'es',
+      fallbackLocale: 'en',
+      messages: {
+        es: { 'toolbar.search': 'Buscar' },
+        en: { 'toolbar.export': 'Export' }
+      }
+    });
+    expect(table.t('toolbar.export')).toBe('Export');
+  });
+
+  test('falls back to the key itself when no locale has it, and warns once', () => {
+    const table = makeTable({ locale: 'es', messages: { es: {} } });
+
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+
+    const missingWarns = warnSpy.mock.calls.filter(c => /totally\.unknown/.test(String(c[0])));
+    expect(missingWarns).toHaveLength(1);
+  });
+
+  test('substitutes {var} placeholders from the vars object', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { 'pagination.pageOf': 'Page {current} of {total}' } }
+    });
+    expect(table.t('pagination.pageOf', { current: 2, total: 10 })).toBe('Page 2 of 10');
+  });
+
+  test('handles repeated and missing placeholders gracefully', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { greet: 'Hi {name}, hi again {name}!' } }
+    });
+    expect(table.t('greet', { name: 'A' })).toBe('Hi A, hi again A!');
+
+    // Missing var leaves the placeholder intact (predictable, debuggable).
+    expect(table.t('greet')).toBe('Hi {name}, hi again {name}!');
+  });
+
+  test('defaults locale to document.documentElement.lang when not set, else "en"', () => {
+    document.documentElement.lang = 'fr';
+    const t1 = makeTable({
+      messages: { fr: { hello: 'Bonjour' } }
+    });
+    expect(t1.t('hello')).toBe('Bonjour');
+
+    document.documentElement.lang = '';
+    const t2 = makeTable({
+      messages: { en: { hello: 'Hello' } }
+    });
+    expect(t2.t('hello')).toBe('Hello');
+  });
+
+  test('returns key with no warning and no error when config.i18n is absent', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', { columns: [{ field: 'id' }] });
+    expect(table.t('toolbar.search')).toBe('toolbar.search');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice of issue #40. Adds a minimal i18n surface so future PRs can replace hard-coded English strings with `this.t('key')` calls.

- `config.i18n: { locale, fallbackLocale, messages, formats }`
- `table.t(key, vars?)` with lookup chain: active locale → fallback locale → key itself (one warn per missing key)
- `{name}` placeholder substitution from `vars`; missing vars leave the placeholder intact for debuggability
- Active locale resolves from `config.i18n.locale`, then `document.documentElement.lang`, then `en`

## Out of scope (tracked in #40, follow-up PRs)
- Pluralisation via `Intl.PluralRules`
- `formatNumber` / `formatDate` helpers
- RTL handling (`dir=\"rtl\"`, `tc-rtl` class)
- `setLocale` / `addMessages` public API
- Built-in locale packs (`src/i18n/{es,fr,de,ar,ur}.json`)
- Migrating existing hard-coded strings (toolbar, pagination, error, confirm) onto `t()`

## Tests
New file `test/i18n.test.js` — 7 cases:
- Active-locale lookup
- Fallback-locale fallthrough
- Key-as-fallback with single warn across repeat calls
- `{var}` substitution
- Repeated and missing placeholders
- Locale resolution from `document.documentElement.lang` and default to `en`
- No-i18n-config call returns the key without error

Full suite: 68/69 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated to this branch.

Refs #40