### PR TITLE
feat(export): exportData(format) dispatcher with JSON support

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2014,6 +2014,55 @@ class TableCrafter {
   }
 
   /**
+   * Export data to JSON. Output is the array of rows as objects, restricted
+   * to the exportable columns. Honours exportFiltered.
+   */
+  exportToJSON() {
+    const exportableColumns = this.getExportableColumns();
+    const exportableData = this.getExportableData();
+
+    const projected = exportableData.map(row => {
+      const out = {};
+      for (const column of exportableColumns) {
+        out[column.field] = row[column.field];
+      }
+      return out;
+    });
+
+    const jsonContent = JSON.stringify(projected);
+
+    if (this.config.onExport) {
+      this.config.onExport({
+        format: 'json',
+        data: projected,
+        jsonData: jsonContent
+      });
+    }
+
+    return jsonContent;
+  }
+
+  /**
+   * Format-dispatching export entry point.
+   * Returns a Promise resolving to the serialized output (string for csv/json)
+   * or rejecting with a clear error for unsupported / not-yet-available formats.
+   */
+  async exportData(format) {
+    switch (format) {
+      case 'csv':
+        return this.exportToCSV();
+      case 'json':
+        return this.exportToJSON();
+      case 'xlsx':
+        throw new Error('xlsx export is not available yet — install the xlsx peer dep when implemented');
+      case 'pdf':
+        throw new Error('pdf export is not available yet — install jspdf + jspdf-autotable when implemented');
+      default:
+        throw new Error(`Unsupported export format: ${format}`);
+    }
+  }
+
+  /**
    * Download CSV file
    */
   downloadCSV() {

--- a/test/export-formats.test.js
+++ b/test/export-formats.test.js
@@ -1,0 +1,82 @@
+/**
+ * Export-format dispatcher (slice of #46) — exportData(format) entry point.
+ * Covers csv pass-through and json output. xlsx, pdf, downloadExport, and
+ * the UI dropdown are deferred to follow-up PRs.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, name: 'Alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob',   email: 'bob@example.com' }
+];
+const columns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns, ...extra });
+}
+
+describe('exportData(format)', () => {
+  test('exportData("csv") returns the same string as exportToCSV()', async () => {
+    const table = makeTable();
+    const result = await table.exportData('csv');
+    expect(result).toBe(table.exportToCSV());
+    expect(typeof result).toBe('string');
+  });
+
+  test('exportData("json") returns valid JSON whose parsed structure matches the visible rows', async () => {
+    const table = makeTable();
+    const result = await table.exportData('json');
+    expect(typeof result).toBe('string');
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual(data);
+  });
+
+  test('exportData("json") respects exportFiltered: false by returning the raw data', async () => {
+    const table = makeTable({ exportFiltered: false });
+    table.searchTerm = 'Alice';
+    const result = await table.exportData('json');
+    expect(JSON.parse(result)).toEqual(data);
+  });
+
+  test('exportData("json") only includes exportable columns', async () => {
+    const table = makeTable({
+      columns: [
+        { field: 'id', label: 'ID' },
+        { field: 'name', label: 'Name' },
+        { field: 'email', label: 'Email', exportable: false }
+      ]
+    });
+    const parsed = JSON.parse(await table.exportData('json'));
+    expect(parsed).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' }
+    ]);
+  });
+
+  test('exportData rejects for an unsupported format with a clear error', async () => {
+    const table = makeTable();
+    await expect(table.exportData('zip')).rejects.toThrow(/unsupported|format/i);
+  });
+
+  test('exportData("xlsx") and exportData("pdf") reject with the not-yet-available message', async () => {
+    const table = makeTable();
+    await expect(table.exportData('xlsx')).rejects.toThrow(/xlsx|not available|not yet/i);
+    await expect(table.exportData('pdf')).rejects.toThrow(/pdf|not available|not yet/i);
+  });
+
+  test('exportData fires onExport callback for json format', async () => {
+    const onExport = jest.fn();
+    const table = makeTable({ onExport });
+    await table.exportData('json');
+    expect(onExport).toHaveBeenCalledWith(expect.objectContaining({
+      format: 'json',
+      data: expect.any(Array)
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice of issue #46. Adds an async `exportData(format)` dispatcher and JSON output path; xlsx/pdf reject with explicit not-yet-available errors so callers fail fast.

- `table.exportData('csv')` — delegates to existing `exportToCSV()` byte-for-byte.
- `table.exportData('json')` — returns a JSON string of the visible rows, restricted to exportable columns, honouring `exportFiltered`.
- `table.exportData('xlsx')` / `table.exportData('pdf')` — reject with explicit \"not available yet\" messages.
- Unknown formats reject with a generic unsupported-format error.
- `exportToJSON()` fires the existing `onExport` callback with `{ format: 'json', data, jsonData }`, mirroring the CSV path's shape.

## Out of scope (tracked in #46)
- xlsx via lazy `xlsx` peer-dep import
- pdf via lazy `jspdf` + `jspdf-autotable`
- `downloadExport(format, filename?)` browser-download helper
- Multi-format UI dropdown in `renderExportControls()`

## Tests
New file `test/export-formats.test.js` — 7 cases:
- csv pass-through equals existing `exportToCSV()` output
- json round-trips via `JSON.parse`
- json respects `exportFiltered: false`
- json only includes columns where `exportable !== false`
- unsupported format rejects clearly
- xlsx and pdf reject with not-yet-available messages
- onExport fires with `{ format: 'json', data }`

Full suite: 68/69 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated to this branch.

Refs #46