### PR TITLE
feat(conditional-formatting): rule evaluator + state API foundation

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -118,6 +118,13 @@ class TableCrafter {
         messages: {},
         formats: {}
       },
+      // Conditional formatting configuration (foundation only — render-loop
+      // wiring, dataBar / colorScale / icon kinds, and aria-label parity
+      // are tracked in #51 follow-ups)
+      conditionalFormatting: {
+        enabled: false,
+        rules: []
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -2915,6 +2922,97 @@ class TableCrafter {
       return document.documentElement.lang;
     }
     return 'en';
+  }
+
+  /**
+   * Conditional formatting — pure rule evaluator.
+   * Accepts either a function predicate `(value, row, ctx) => boolean` or a
+   * declarative `{ op, value }` predicate. Unknown ops resolve to `false`
+   * rather than throw, so a single bad rule cannot break the render.
+   */
+  evaluateRule(rule, value, row) {
+    if (!rule || rule.when == null) return false;
+
+    if (typeof rule.when === 'function') {
+      try {
+        return Boolean(rule.when(value, row, { table: this, field: rule.field }));
+      } catch (e) {
+        console.warn('TableCrafter: conditional-formatting predicate threw', e);
+        return false;
+      }
+    }
+
+    const { op, value: target } = rule.when;
+    switch (op) {
+      case 'gt':       return Number(value) > Number(target);
+      case 'lt':       return Number(value) < Number(target);
+      case 'gte':      return Number(value) >= Number(target);
+      case 'lte':      return Number(value) <= Number(target);
+      case 'eq':       return value === target;
+      case 'neq':      return value !== target;
+      case 'between': {
+        if (!Array.isArray(target) || target.length !== 2) return false;
+        const n = Number(value);
+        return n >= Number(target[0]) && n <= Number(target[1]);
+      }
+      case 'contains': return String(value ?? '').includes(String(target ?? ''));
+      case 'empty':    return value === null || value === undefined || value === '';
+      case 'regex': {
+        try {
+          return new RegExp(target).test(String(value ?? ''));
+        } catch (e) {
+          return false;
+        }
+      }
+      default:         return false;
+    }
+  }
+
+  /**
+   * Return the rules that apply to a given (field, value, row) tuple, sorted
+   * by descending priority (default 0). Wildcard rules (`field: '*'`) match
+   * every field. Returns [] when conditional formatting is disabled.
+   */
+  getMatchingRules(field, value, row) {
+    const cfg = this.config && this.config.conditionalFormatting;
+    if (!cfg || !cfg.enabled || !Array.isArray(cfg.rules)) return [];
+
+    const candidates = cfg.rules.filter(r => r.field === field || r.field === '*');
+    const matches = candidates.filter(r => this.evaluateRule(r, value, row));
+    return matches.slice().sort((a, b) => (b.priority || 0) - (a.priority || 0));
+  }
+
+  /**
+   * Append a conditional-formatting rule and re-render.
+   */
+  addRule(rule) {
+    if (!this.config.conditionalFormatting) {
+      this.config.conditionalFormatting = { enabled: true, rules: [] };
+    }
+    if (!Array.isArray(this.config.conditionalFormatting.rules)) {
+      this.config.conditionalFormatting.rules = [];
+    }
+    this.config.conditionalFormatting.rules.push(rule);
+    this.render();
+    return rule;
+  }
+
+  removeRule(id) {
+    const rules = this.config.conditionalFormatting && this.config.conditionalFormatting.rules;
+    if (!Array.isArray(rules)) return false;
+    const before = rules.length;
+    this.config.conditionalFormatting.rules = rules.filter(r => r.id !== id);
+    const removed = this.config.conditionalFormatting.rules.length < before;
+    if (removed) this.render();
+    return removed;
+  }
+
+  setRules(rules) {
+    if (!this.config.conditionalFormatting) {
+      this.config.conditionalFormatting = { enabled: true, rules: [] };
+    }
+    this.config.conditionalFormatting.rules = Array.isArray(rules) ? rules.slice() : [];
+    this.render();
   }
 
   /**

--- a/test/conditional-formatting.test.js
+++ b/test/conditional-formatting.test.js
@@ -1,0 +1,143 @@
+/**
+ * Conditional formatting foundation (slice of #51).
+ *
+ * This PR lands only:
+ *   - the config.conditionalFormatting surface
+ *   - addRule / removeRule / setRules public API
+ *   - evaluateRule(rule, value, row) pure evaluator (function + core ops)
+ *   - getMatchingRules(field, value, row) lookup helper
+ *
+ * Render-loop wiring (className / style / dataBar / colorScale / aria-label)
+ * is intentionally deferred to follow-up PRs and remains tracked in #51.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'value', label: 'Value' }],
+    data: [{ value: 1 }, { value: 5 }, { value: 10 }],
+    ...extra
+  });
+}
+
+describe('Conditional formatting: evaluateRule', () => {
+  test('function predicate is invoked with (value, row, ctx)', () => {
+    const table = makeTable();
+    const fn = jest.fn(() => true);
+    const row = { value: 7 };
+    expect(table.evaluateRule({ id: 'r1', field: 'value', when: fn }, 7, row)).toBe(true);
+    expect(fn).toHaveBeenCalledWith(7, row, expect.any(Object));
+  });
+
+  test('declarative gt / lt / eq / neq', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'gt', value: 5 } }, 6)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'gt', value: 5 } }, 5)).toBe(false);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'lt', value: 5 } }, 4)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'eq', value: 'a' } }, 'a')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'neq', value: 'a' } }, 'b')).toBe(true);
+  });
+
+  test('declarative between / contains / empty', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'between', value: [1, 10] } }, 5)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'between', value: [1, 10] } }, 11)).toBe(false);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'contains', value: 'oo' } }, 'foobar')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'empty' } }, '')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'empty' } }, 'x')).toBe(false);
+  });
+
+  test('declarative regex', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'regex', value: '^foo' } }, 'foobar')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'regex', value: '^foo' } }, 'barfoo')).toBe(false);
+  });
+
+  test('returns false for unknown op without throwing', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'xyz', value: 5 } }, 5)).toBe(false);
+  });
+});
+
+describe('Conditional formatting: rule state API', () => {
+  test('addRule appends, getMatchingRules returns matches in priority order', () => {
+    const table = makeTable({
+      conditionalFormatting: { enabled: true, rules: [] }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.addRule({ id: 'low', field: 'value', when: { op: 'lt', value: 3 }, className: 'low', priority: 0 });
+    table.addRule({ id: 'critical', field: 'value', when: { op: 'lt', value: 2 }, className: 'critical', priority: 5 });
+    table.addRule({ id: 'high', field: 'value', when: { op: 'gt', value: 100 }, className: 'high', priority: 0 });
+
+    const matches = table.getMatchingRules('value', 1, { value: 1 });
+    expect(matches.map(r => r.id)).toEqual(['critical', 'low']); // higher priority first
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('removeRule removes by id and re-renders', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [
+          { id: 'r1', field: 'value', when: () => true, className: 'a' },
+          { id: 'r2', field: 'value', when: () => true, className: 'b' }
+        ]
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.removeRule('r1');
+
+    expect(table.config.conditionalFormatting.rules.map(r => r.id)).toEqual(['r2']);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('setRules replaces the rule list and re-renders', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{ id: 'old', field: 'value', when: () => true }]
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.setRules([
+      { id: 'new1', field: 'value', when: () => true },
+      { id: 'new2', field: 'value', when: () => true }
+    ]);
+
+    expect(table.config.conditionalFormatting.rules.map(r => r.id)).toEqual(['new1', 'new2']);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('getMatchingRules returns [] when conditionalFormatting is disabled', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: false,
+        rules: [{ id: 'r1', field: 'value', when: () => true }]
+      }
+    });
+    expect(table.getMatchingRules('value', 1, { value: 1 })).toEqual([]);
+  });
+
+  test('getMatchingRules respects field — wildcard "*" rules match every field', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [
+          { id: 'specific', field: 'value', when: () => true, scope: 'cell' },
+          { id: 'wildcard', field: '*', when: () => true, scope: 'row' }
+        ]
+      }
+    });
+
+    const matches = table.getMatchingRules('value', 1, { value: 1 });
+    const otherField = table.getMatchingRules('something_else', 1, { value: 1 });
+
+    expect(matches.map(r => r.id).sort()).toEqual(['specific', 'wildcard']);
+    expect(otherField.map(r => r.id)).toEqual(['wildcard']);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice of issue #51. Lands the rule evaluator, lookup, and state-management surface without yet wiring it into the render loop — so the next PR can focus purely on render integration.

- `config.conditionalFormatting: { enabled, rules }` default surface.
- `evaluateRule(rule, value, row)` — function predicates plus the declarative ops `gt / lt / gte / lte / eq / neq / between / contains / empty / regex`. Unknown ops resolve to `false` (a malformed rule can't break the render).
- `getMatchingRules(field, value, row)` — wildcard `field: '*'` rules match every column; results sorted by descending priority. Returns `[]` when disabled.
- `addRule(rule)` / `removeRule(id)` / `setRules(rules)` public API; each re-renders on successful mutation.

## Out of scope (tracked in #51)
- Render-loop wiring (`className` / `style` application on `<td>` / `<tr>`)
- `kind: 'dataBar'`, `kind: 'colorScale'`, `kind: 'icon'` visualisations
- A11y `aria-label` parity for visual-only cues
- Performance benchmark (1000 × 5 rules under 50ms)

## Tests
New file `test/conditional-formatting.test.js` — 10 cases:
- Function predicate receives `(value, row, ctx)`.
- Each declarative op (`gt`, `lt`, `eq`, `neq`, `between`, `contains`, `empty`, `regex`) on positive and negative paths.
- Unknown op returns `false`, doesn't throw.
- `addRule` with mixed priorities → `getMatchingRules` orders correctly.
- `removeRule` filters by id and re-renders.
- `setRules` replaces and re-renders.
- Disabled config returns `[]`.
- Wildcard `field: '*'` matches arbitrary fields.

Full suite: 71/72 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated to this branch.

Refs #51