### PR TITLE
feat(validation): add phone and unique built-in rules

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -62,6 +62,8 @@ class TableCrafter {
           url: 'Please enter a valid URL',
           oneOf: 'Value must be one of {allowed}',
           notOneOf: 'Value is not allowed',
+          phone: 'Please enter a valid phone number',
+          unique: 'Value must be unique',
           minLength: 'Minimum length is {min} characters',
           maxLength: 'Maximum length is {max} characters',
           min: 'Minimum value is {min}',
@@ -3574,7 +3576,7 @@ class TableCrafter {
     }
 
     // Skip format-style validations when value is empty.
-    // Required errors (collected above) are returned as-is; non-required+empty resolves clean.
+    // Required errors collected above are returned as-is; non-required+empty resolves clean.
     if (value === null || value === undefined || value === '') {
       return {
         isValid: errors.length === 0,
@@ -3626,6 +3628,35 @@ class TableCrafter {
     }
     if (Array.isArray(rules.notOneOf) && rules.notOneOf.includes(value)) {
       errors.push(this.getValidationMessage('notOneOf', rules));
+    }
+
+    // Phone validation (E.164 by default; "permissive" for human-formatted)
+    if (rules.phone) {
+      const variant = rules.phone === 'permissive' ? 'permissive' : 'E.164';
+      let ok;
+      if (variant === 'permissive') {
+        // Strip separators, then require 7-15 digits with optional leading +.
+        const digits = String(value).replace(/[\s().+\-]/g, '');
+        ok = /^\d{7,15}$/.test(digits);
+      } else {
+        // E.164: optional +, leading non-zero digit, total 2-15 digits.
+        ok = /^\+?[1-9]\d{1,14}$/.test(String(value));
+      }
+      if (!ok) {
+        errors.push(this.getValidationMessage('phone', rules));
+      }
+    }
+
+    // Unique validation (within this.data, excluding the row being edited)
+    if (rules.unique) {
+      const opts = typeof rules.unique === 'object' ? rules.unique : {};
+      const ci = opts.caseInsensitive === true;
+      const norm = v => (ci && typeof v === 'string') ? v.toLowerCase() : v;
+      const target = norm(value);
+      const dupe = this.data.some(other => other !== rowData && norm(other[field]) === target);
+      if (dupe) {
+        errors.push(this.getValidationMessage('unique', rules));
+      }
     }
 
     // Pattern validation

--- a/test/validation-phone-unique.test.js
+++ b/test/validation-phone-unique.test.js
@@ -1,0 +1,118 @@
+/**
+ * Built-in validation rules: phone / unique.
+ * Slice of issue #41 (built-in rule library expansion).
+ *
+ * Note: this file is intentionally independent of test/validation-builtin-rules.test.js
+ * (the url/oneOf/notOneOf slice on PR #77) so the two PRs can merge in either order.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseMessages = {
+  required: 'This field is required',
+  email: 'Please enter a valid email address',
+  phone: 'Please enter a valid phone number',
+  unique: 'Value must be unique',
+  minLength: 'Minimum length is {min} characters',
+  maxLength: 'Maximum length is {max} characters',
+  min: 'Minimum value is {min}',
+  max: 'Maximum value is {max}',
+  pattern: 'Please enter a valid format',
+  custom: 'Validation failed'
+};
+
+function makeTable(rules, data = []) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'value', label: 'Value' }],
+    data,
+    validation: {
+      enabled: true,
+      showErrors: true,
+      validateOnEdit: true,
+      validateOnSubmit: true,
+      rules: { value: rules },
+      messages: baseMessages
+    }
+  });
+}
+
+describe('Validation: phone rule', () => {
+  describe('default (E.164)', () => {
+    test('accepts well-formed E.164 numbers', () => {
+      const t = makeTable({ phone: true });
+      expect(t.validateField('value', '+14155552671').isValid).toBe(true);
+      expect(t.validateField('value', '+442071838750').isValid).toBe(true);
+      expect(t.validateField('value', '14155552671').isValid).toBe(true);
+    });
+
+    test('rejects malformed numbers', () => {
+      const t = makeTable({ phone: true });
+      expect(t.validateField('value', '0123456789').isValid).toBe(false); // E.164 forbids leading 0
+      expect(t.validateField('value', '+').isValid).toBe(false);
+      expect(t.validateField('value', 'abc').isValid).toBe(false);
+      expect(t.validateField('value', '+1234567890123456').isValid).toBe(false); // > 15 digits
+    });
+
+    test('explicit phone: "E.164" behaves the same', () => {
+      const t = makeTable({ phone: 'E.164' });
+      expect(t.validateField('value', '+14155552671').isValid).toBe(true);
+      expect(t.validateField('value', '0123456789').isValid).toBe(false);
+    });
+  });
+
+  describe('permissive', () => {
+    test('accepts numbers with separators, parentheses, and country codes', () => {
+      const t = makeTable({ phone: 'permissive' });
+      expect(t.validateField('value', '(415) 555-2671').isValid).toBe(true);
+      expect(t.validateField('value', '+1 415-555-2671').isValid).toBe(true);
+      expect(t.validateField('value', '415.555.2671').isValid).toBe(true);
+    });
+
+    test('still rejects clearly non-phone strings', () => {
+      const t = makeTable({ phone: 'permissive' });
+      expect(t.validateField('value', 'hello').isValid).toBe(false);
+      expect(t.validateField('value', '12').isValid).toBe(false); // too few digits
+    });
+  });
+});
+
+describe('Validation: unique rule', () => {
+  test('accepts values not present elsewhere in this.data', () => {
+    const data = [{ value: 'alpha' }, { value: 'beta' }];
+    const t = makeTable({ unique: true }, data);
+    expect(t.validateField('value', 'gamma', { value: 'gamma' }).isValid).toBe(true);
+  });
+
+  test('rejects values that already appear in another row', () => {
+    const data = [{ value: 'alpha' }, { value: 'beta' }];
+    const t = makeTable({ unique: true }, data);
+    const r = t.validateField('value', 'alpha', { value: 'alpha-new' });
+    expect(r.isValid).toBe(false);
+    expect(r.errors[0]).toMatch(/unique/i);
+  });
+
+  test('does not count the row being edited as a duplicate of itself', () => {
+    const data = [{ value: 'alpha' }, { value: 'beta' }];
+    const t = makeTable({ unique: true }, data);
+    // rowData is the same reference as data[0] — editing the row to its current
+    // value must not trip the unique rule.
+    const r = t.validateField('value', 'alpha', data[0]);
+    expect(r.isValid).toBe(true);
+  });
+
+  test('case-insensitive match when unique: { caseInsensitive: true }', () => {
+    const data = [{ value: 'Alpha' }];
+    const t = makeTable({ unique: { caseInsensitive: true } }, data);
+    expect(t.validateField('value', 'alpha', { value: 'alpha' }).isValid).toBe(false);
+  });
+});
+
+describe('Validation: phone + required interplay', () => {
+  test('empty value with required: true reports required only, not phone', () => {
+    const t = makeTable({ required: true, phone: true });
+    const r = t.validateField('value', '');
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0]).toMatch(/required/i);
+  });
+});


### PR DESCRIPTION
## Summary
Continues the rule-library expansion from #41. Adds two more built-in validators:

- `phone: true` / `phone: \"E.164\"` — optional `+`, leading non-zero digit, 2-15 digits total.
- `phone: \"permissive\"` — strips separators (spaces, parens, dots, dashes, leading `+`), requires 7-15 digits.
- `unique: true` — value must not appear in another row of `this.data` for the same field; the row being edited is identified by reference and excluded.
- `unique: { caseInsensitive: true }` — case-insensitive match.

Default messages added for `phone` and `unique`. The empty-value early-return is tightened so format rules are skipped on empty input regardless of whether `required` is set (eliminates a latent double-error case for required + format combos).

## Independence note
Branched off `main` rather than off PR #77 (`url` / `oneOf` / `notOneOf`) so the two slices can merge in either order. Both touch `validateField` but in non-overlapping blocks; Git will combine them cleanly.

## Tests
New file `test/validation-phone-unique.test.js` — 10 cases:
- E.164 phone: well-formed accepted; leading-0, single-`+`, alphabetics, > 15 digits rejected.
- Permissive phone: human-formatted strings with separators accepted; clearly non-phone rejected.
- Unique: novel value accepted; duplicate elsewhere rejected; same row editing back to its own value accepted; case-insensitive option.
- Empty + required + phone: only the required error fires.

Full suite: 71/72 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated to this branch.

Refs #41