### PR TITLE
feat(i18n): setLocale, addMessages, and {one, other} plural forms

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2740,8 +2740,27 @@ class TableCrafter {
       template = key;
     }
 
+    // Pluralisation: if the catalogue entry is a {one, other, few, ...} object
+    // and vars.count is set, pick the matching form via Intl.PluralRules.
+    if (template && typeof template === 'object' && vars && typeof vars.count === 'number') {
+      const locale = this._resolveLocale();
+      let form = 'other';
+      try {
+        form = new Intl.PluralRules(locale).select(vars.count);
+      } catch (e) {
+        // Locale unsupported by Intl.PluralRules — keep 'other'.
+      }
+      if (Object.prototype.hasOwnProperty.call(template, form)) {
+        template = template[form];
+      } else if (Object.prototype.hasOwnProperty.call(template, 'other')) {
+        template = template.other;
+      } else {
+        template = key; // No usable plural form — fall back to the key.
+      }
+    }
+
     if (typeof template !== 'string' || !vars) {
-      return template;
+      return typeof template === 'string' ? template : key;
     }
     return template.replace(/\{(\w+)\}/g, (m, name) => {
       return Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : m;
@@ -2755,6 +2774,31 @@ class TableCrafter {
       return document.documentElement.lang;
     }
     return 'en';
+  }
+
+  /**
+   * Switch the active locale and re-render. No-op (no render) when the locale
+   * is already current — avoids needless DOM rebuilds.
+   */
+  setLocale(locale) {
+    if (!this.config) this.config = {};
+    if (!this.config.i18n) this.config.i18n = { fallbackLocale: 'en', messages: {} };
+    if (this.config.i18n.locale === locale) return;
+    this.config.i18n.locale = locale;
+    this.render();
+  }
+
+  /**
+   * Merge translations into the catalogue at runtime. Existing keys for the
+   * given locale are overwritten by the supplied messages; new locales are
+   * created on demand.
+   */
+  addMessages(locale, messages) {
+    if (!this.config) this.config = {};
+    if (!this.config.i18n) this.config.i18n = { fallbackLocale: 'en', messages: {} };
+    if (!this.config.i18n.messages) this.config.i18n.messages = {};
+    const bucket = this.config.i18n.messages[locale] || {};
+    this.config.i18n.messages[locale] = Object.assign(bucket, messages || {});
   }
 
   /**

--- a/test/i18n-extras.test.js
+++ b/test/i18n-extras.test.js
@@ -1,0 +1,106 @@
+/**
+ * Stacked on PR #78 (i18n t() helper foundation).
+ * Adds: setLocale(), addMessages(), and {one, other} plural forms.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(i18n) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }], i18n });
+}
+
+describe('i18n: setLocale()', () => {
+  test('switches active locale and re-renders', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: { hello: 'Hello' },
+        es: { hello: 'Hola' }
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    expect(table.t('hello')).toBe('Hello');
+    table.setLocale('es');
+    expect(table.t('hello')).toBe('Hola');
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('setLocale to the same locale is a no-op (no extra render)', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { hello: 'Hello' } }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+    table.setLocale('en');
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('i18n: addMessages()', () => {
+  test('merges new keys into the active locale catalogue', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { hello: 'Hello' } }
+    });
+    table.addMessages('en', { goodbye: 'Goodbye' });
+    expect(table.t('hello')).toBe('Hello');
+    expect(table.t('goodbye')).toBe('Goodbye');
+  });
+
+  test('overrides existing keys when re-added', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { greet: 'Hi' } }
+    });
+    table.addMessages('en', { greet: 'Hello there' });
+    expect(table.t('greet')).toBe('Hello there');
+  });
+
+  test('creates a new locale bucket if it did not exist', () => {
+    const table = makeTable({ locale: 'en', messages: { en: {} } });
+    table.addMessages('fr', { hello: 'Bonjour' });
+    table.setLocale('fr');
+    expect(table.t('hello')).toBe('Bonjour');
+  });
+});
+
+describe('i18n: pluralisation', () => {
+  test('selects the {one, other} form based on vars.count', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: {
+          'rows.selected': {
+            one: '1 row selected',
+            other: '{count} rows selected'
+          }
+        }
+      }
+    });
+    expect(table.t('rows.selected', { count: 1 })).toBe('1 row selected');
+    expect(table.t('rows.selected', { count: 5 })).toBe('5 rows selected');
+    expect(table.t('rows.selected', { count: 0 })).toBe('0 rows selected');
+  });
+
+  test('falls back to "other" when "one" is missing', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: { items: { other: '{count} items' } }
+      }
+    });
+    expect(table.t('items', { count: 1 })).toBe('1 items');
+    expect(table.t('items', { count: 3 })).toBe('3 items');
+  });
+
+  test('returns the object stringified key when no plural forms match', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { weird: { few: 'few' } } }
+    });
+    // No 'one' or 'other' — fall back to the raw key for visibility.
+    expect(table.t('weird', { count: 1 })).toBe('weird');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on top of PR #78 (foundation `t()` helper). Targets that branch so reviewers see only the additive diff. GitHub will retarget this PR at `main` automatically when #78 merges.

Adds:

- `setLocale(locale)` — switches active locale and re-renders. No-op when the locale is already current (avoids needless DOM rebuild).
- `addMessages(locale, messages)` — merges new translations into the catalogue at runtime; creates a new locale bucket on demand.
- `t()` pluralisation — when the catalogue entry is a `{ one, other, few, ... }` object and `vars.count` is a number, the right form is chosen via `Intl.PluralRules`. Falls through to `'other'` when the chosen form is missing; falls through to the raw key when neither is usable so the gap is visible.

## Out of scope (tracked in #40)
- `formatNumber` / `formatDate` helpers
- RTL handling (`dir=\"rtl\"`, `tc-rtl` class, mirrored sort indicators)
- Built-in locale packs (`src/i18n/{es,fr,de,ar,ur}.json`)
- Migrating hard-coded English strings onto `t()`

## Tests
New file `test/i18n-extras.test.js` — 8 cases:
- `setLocale` switches and re-renders.
- `setLocale` to current locale is a no-op.
- `addMessages` merges new keys, overwrites existing, creates new locale bucket.
- `t()` plural picks `one` vs `other` based on `count`.
- `t()` falls through to `other` when `one` is missing.
- `t()` falls back to the key when no usable plural form exists.

Foundation tests (`test/i18n.test.js`, 7 cases from PR #78) continue to pass — combined 15/15 i18n tests green.

Full suite: 76/77 pass. Remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #40