### PR TITLE
feat(plugins): plugin registry foundation (use / unuse / getPlugins)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -164,6 +164,19 @@ class TableCrafter {
     this.validationRules = new Map(); // Compiled validation rules
     this.cellTypeRegistry = new Map(); // Rich cell type handlers
     this.activeEditors = new Map(); // Track active rich editors
+    this._plugins = []; // Plugin registry — populated via use() / config.plugins
+
+    // Auto-register plugins declared in config.plugins (in order, before any
+    // render). Each entry is either a plugin object or [plugin, options].
+    if (Array.isArray(this.config.plugins)) {
+      for (const entry of this.config.plugins) {
+        if (Array.isArray(entry)) {
+          this.use(entry[0], entry[1]);
+        } else {
+          this.use(entry);
+        }
+      }
+    }
 
     // Load state if persistence enabled
     this.loadState();
@@ -2946,7 +2959,6 @@ class TableCrafter {
   }
 
   /**
-<<<<<<< HEAD
    * Conditional formatting — pure rule evaluator.
    * Accepts either a function predicate `(value, row, ctx) => boolean` or a
    * declarative `{ op, value }` predicate. Unknown ops resolve to `false`
@@ -3060,6 +3072,53 @@ class TableCrafter {
     if (!this.config.i18n.messages) this.config.i18n.messages = {};
     const bucket = this.config.i18n.messages[locale] || {};
     this.config.i18n.messages[locale] = Object.assign(bucket, messages || {});
+  }
+
+  /**
+   * Register a plugin. Calls `plugin.install(table, options)` and stores it
+   * in the registry under `plugin.name`. Re-registering the same name throws.
+   */
+  use(plugin, options) {
+    if (!plugin || !plugin.name || typeof plugin.name !== 'string') {
+      throw new Error('TableCrafter: plugin must have a string `name`');
+    }
+    if (this._plugins.some(p => p.plugin.name === plugin.name)) {
+      throw new Error(`TableCrafter: plugin "${plugin.name}" is already registered`);
+    }
+
+    const record = { plugin, options: options };
+    if (typeof plugin.install === 'function') {
+      plugin.install(this, options);
+    }
+    this._plugins.push(record);
+    return record;
+  }
+
+  /**
+   * Remove a plugin by name. Calls plugin.uninstall(table) when defined.
+   * Returns true on success, false when no plugin matches.
+   */
+  unuse(name) {
+    const idx = this._plugins.findIndex(p => p.plugin.name === name);
+    if (idx === -1) return false;
+    const { plugin } = this._plugins[idx];
+    if (typeof plugin.uninstall === 'function') {
+      plugin.uninstall(this);
+    }
+    this._plugins.splice(idx, 1);
+    return true;
+  }
+
+  /**
+   * Defensive snapshot of the plugin registry. Mutating the returned array
+   * does not affect internal state.
+   */
+  getPlugins() {
+    return this._plugins.map(p => ({
+      name: p.plugin.name,
+      version: p.plugin.version,
+      options: p.options
+    }));
   }
 
   /**

--- a/test/plugin-architecture.test.js
+++ b/test/plugin-architecture.test.js
@@ -1,0 +1,136 @@
+/**
+ * Plugin architecture foundation (slice of #38).
+ *
+ * This PR lands only:
+ *   - the public registry: use() / unuse() / getPlugins()
+ *   - config.plugins: [...] auto-registration during construction
+ *
+ * Hook firing (beforeRender / afterRender / beforeEdit / etc.), cancel-on-false
+ * semantics, and error-isolation are intentionally deferred to follow-up PRs
+ * and remain tracked in the AC posted on #38.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }], ...extra });
+}
+
+describe('Plugin registry: use()', () => {
+  test('calls install(table, options) exactly once and registers the plugin', () => {
+    const table = makeTable();
+    const install = jest.fn();
+    const plugin = { name: 'audit', version: '1.0.0', install };
+
+    table.use(plugin, { mode: 'silent' });
+
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledWith(table, { mode: 'silent' });
+    expect(table.getPlugins().map(p => p.name)).toContain('audit');
+  });
+
+  test('throws when registering a duplicate name', () => {
+    const table = makeTable();
+    const plugin = { name: 'dup', install: () => {} };
+    table.use(plugin);
+    expect(() => table.use(plugin)).toThrow(/already registered|duplicate/i);
+  });
+
+  test('rejects plugins missing a name', () => {
+    const table = makeTable();
+    expect(() => table.use({ install: () => {} })).toThrow(/name/i);
+  });
+
+  test('install is optional — a hook-only plugin still registers', () => {
+    const table = makeTable();
+    const plugin = { name: 'hooks-only', hooks: {} };
+    expect(() => table.use(plugin)).not.toThrow();
+    expect(table.getPlugins().map(p => p.name)).toContain('hooks-only');
+  });
+});
+
+describe('Plugin registry: unuse()', () => {
+  test('calls uninstall(table) and removes the plugin from the registry', () => {
+    const table = makeTable();
+    const uninstall = jest.fn();
+    table.use({ name: 'p1', install: () => {}, uninstall });
+
+    const removed = table.unuse('p1');
+
+    expect(removed).toBe(true);
+    expect(uninstall).toHaveBeenCalledWith(table);
+    expect(table.getPlugins().map(p => p.name)).not.toContain('p1');
+  });
+
+  test('returns false when no such plugin exists', () => {
+    const table = makeTable();
+    expect(table.unuse('ghost')).toBe(false);
+  });
+
+  test('uninstall is optional — unuse still succeeds and removes it', () => {
+    const table = makeTable();
+    table.use({ name: 'p2', install: () => {} });
+    expect(table.unuse('p2')).toBe(true);
+    expect(table.getPlugins().map(p => p.name)).not.toContain('p2');
+  });
+
+  test('unuse then use of the same name succeeds', () => {
+    const table = makeTable();
+    const plugin = { name: 'cycle', install: () => {} };
+    table.use(plugin);
+    table.unuse('cycle');
+    expect(() => table.use(plugin)).not.toThrow();
+    expect(table.getPlugins().map(p => p.name)).toContain('cycle');
+  });
+});
+
+describe('Plugin registry: getPlugins()', () => {
+  test('returns a defensive copy that does not affect internal state', () => {
+    const table = makeTable();
+    table.use({ name: 'a', install: () => {} });
+    table.use({ name: 'b', install: () => {} });
+
+    const list = table.getPlugins();
+    list.length = 0;
+
+    expect(table.getPlugins().map(p => p.name)).toEqual(['a', 'b']);
+  });
+
+  test('reports name, version, and resolved options', () => {
+    const table = makeTable();
+    table.use({ name: 'p', version: '2.1.0', install: () => {} }, { foo: 1 });
+
+    const [record] = table.getPlugins();
+    expect(record.name).toBe('p');
+    expect(record.version).toBe('2.1.0');
+    expect(record.options).toEqual({ foo: 1 });
+  });
+});
+
+describe('Plugin registry: config.plugins auto-registration', () => {
+  test('plugins listed in config.plugins are registered before first render', () => {
+    const installA = jest.fn();
+    const installB = jest.fn();
+
+    const table = makeTable({
+      plugins: [
+        { name: 'a', install: installA },
+        [{ name: 'b', install: installB }, { count: 5 }]
+      ]
+    });
+
+    expect(installA).toHaveBeenCalled();
+    expect(installB).toHaveBeenCalledWith(table, { count: 5 });
+    expect(table.getPlugins().map(p => p.name)).toEqual(['a', 'b']);
+  });
+
+  test('registration preserves declaration order', () => {
+    const calls = [];
+    const make = name => ({ name, install: () => calls.push(name) });
+
+    makeTable({ plugins: [make('first'), make('second'), make('third')] });
+
+    expect(calls).toEqual(['first', 'second', 'third']);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice of issue #38. Adds the public plugin-registry surface and config-driven auto-registration. Lifecycle-hook firing (the meat of plugin extensibility) is deferred to follow-up PRs so this one can land cleanly with a small surface area.

I also posted comprehensive AC + a TDD plan as a comment on #38 (the issue body was previously a one-liner). This PR implements the registry portion of that plan.

- `use(plugin, options?)` — calls `plugin.install(table, options)` and stores it under `plugin.name`. Duplicate names throw; missing `install` is allowed (hook-only plugins).
- `unuse(name)` — calls `plugin.uninstall(table)` when defined, removes the record. Returns `true` on hit, `false` on miss.
- `getPlugins()` — returns a defensive copy as `{ name, version, options }[]`.
- `config.plugins: Array<plugin | [plugin, options]>` — auto-registered in declaration order during construction, before any render.

## Out of scope (tracked in #38 AC)
- Hook firing for `beforeRender` / `afterRender` / `beforeLoad` / `afterLoad` / `beforeEdit` / `afterEdit` / `beforeSort` / `afterSort` / `destroy`
- Cancel-on-`false` semantics for `before*` hooks
- Error isolation (`try/catch` around handlers, `console.warn` for thrown errors in `after*` hooks)
- Plugin-to-plugin dependency resolution

## Tests
New file `test/plugin-architecture.test.js` — 12 cases:
- `use` calls `install(table, options)` once with the right args.
- Duplicate-name registration throws.
- Plugins without a `name` rejected.
- `install` optional — hook-only plugins still register.
- `unuse` calls `uninstall(table)` and removes from registry.
- `unuse` of unknown name returns `false`.
- `uninstall` optional.
- `unuse` then `use` of the same name succeeds.
- `getPlugins()` is a defensive copy.
- `getPlugins()` reports `name` / `version` / `options`.
- `config.plugins` auto-registration with mixed `plugin` and `[plugin, options]` entries.
- Auto-registration order matches declaration order.

Full suite: 73/74 pass. Remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38