### PR TITLE
feat(plugins): wire beforeRender / afterRender hooks + _fireHook helper

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -595,6 +595,11 @@ class TableCrafter {
   }
 
   render() {
+    // Plugin lifecycle: beforeRender. Cancel-on-false skips the entire render.
+    if (this._fireHook && this._fireHook('beforeRender', { table: this }) === false) {
+      return;
+    }
+
     // Check if we are hydrating (SSR content already present)
     const isHydrating = this.container.dataset.ssr === "true" &&
       (this.container.querySelector('table') || this.container.querySelector('.tc-cards-container') || this.container.querySelector('.tc-loading') || this.container.querySelector('.tc-wrapper'));
@@ -684,6 +689,9 @@ class TableCrafter {
     if (this.config.pagination && this.shouldShowPagination()) {
       wrapper.appendChild(this.renderPagination());
     }
+
+    // Plugin lifecycle: afterRender. Return value is ignored.
+    if (this._fireHook) this._fireHook('afterRender', { table: this });
   }
 
   /**
@@ -2764,6 +2772,30 @@ class TableCrafter {
       version: p.plugin.version,
       options: p.options
     }));
+  }
+
+  /**
+   * Fire a named lifecycle hook across all registered plugins, in registration
+   * order. Returns false if any handler returned false or threw — callers in
+   * `before*` paths use that as the cancel signal. `after*` callers may ignore
+   * the return value. Errors are caught and warned so a single bad plugin
+   * cannot break the table.
+   */
+  _fireHook(name, payload) {
+    let proceed = true;
+    if (!Array.isArray(this._plugins)) return proceed;
+    for (const record of this._plugins) {
+      const fn = record.plugin && record.plugin.hooks && record.plugin.hooks[name];
+      if (typeof fn !== 'function') continue;
+      try {
+        const result = fn.call(record.plugin, payload, this);
+        if (result === false) proceed = false;
+      } catch (e) {
+        console.warn(`TableCrafter: plugin "${record.plugin.name}" threw in hook "${name}":`, e);
+        proceed = false;
+      }
+    }
+    return proceed;
   }
 
   /**

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -144,6 +144,19 @@ class TableCrafter {
     this.validationRules = new Map(); // Compiled validation rules
     this.cellTypeRegistry = new Map(); // Rich cell type handlers
     this.activeEditors = new Map(); // Track active rich editors
+    this._plugins = []; // Plugin registry — populated via use() / config.plugins
+
+    // Auto-register plugins declared in config.plugins (in order, before any
+    // render). Each entry is either a plugin object or [plugin, options].
+    if (Array.isArray(this.config.plugins)) {
+      for (const entry of this.config.plugins) {
+        if (Array.isArray(entry)) {
+          this.use(entry[0], entry[1]);
+        } else {
+          this.use(entry);
+        }
+      }
+    }
 
     // Load state if persistence enabled
     this.loadState();
@@ -2705,6 +2718,53 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Register a plugin. Calls `plugin.install(table, options)` and stores it
+   * in the registry under `plugin.name`. Re-registering the same name throws.
+   */
+  use(plugin, options) {
+    if (!plugin || !plugin.name || typeof plugin.name !== 'string') {
+      throw new Error('TableCrafter: plugin must have a string `name`');
+    }
+    if (this._plugins.some(p => p.plugin.name === plugin.name)) {
+      throw new Error(`TableCrafter: plugin "${plugin.name}" is already registered`);
+    }
+
+    const record = { plugin, options: options };
+    if (typeof plugin.install === 'function') {
+      plugin.install(this, options);
+    }
+    this._plugins.push(record);
+    return record;
+  }
+
+  /**
+   * Remove a plugin by name. Calls plugin.uninstall(table) when defined.
+   * Returns true on success, false when no plugin matches.
+   */
+  unuse(name) {
+    const idx = this._plugins.findIndex(p => p.plugin.name === name);
+    if (idx === -1) return false;
+    const { plugin } = this._plugins[idx];
+    if (typeof plugin.uninstall === 'function') {
+      plugin.uninstall(this);
+    }
+    this._plugins.splice(idx, 1);
+    return true;
+  }
+
+  /**
+   * Defensive snapshot of the plugin registry. Mutating the returned array
+   * does not affect internal state.
+   */
+  getPlugins() {
+    return this._plugins.map(p => ({
+      name: p.plugin.name,
+      version: p.plugin.version,
+      options: p.options
+    }));
+  }
 
   /**
    * Set current user context

--- a/test/plugin-architecture.test.js
+++ b/test/plugin-architecture.test.js
@@ -1,0 +1,136 @@
+/**
+ * Plugin architecture foundation (slice of #38).
+ *
+ * This PR lands only:
+ *   - the public registry: use() / unuse() / getPlugins()
+ *   - config.plugins: [...] auto-registration during construction
+ *
+ * Hook firing (beforeRender / afterRender / beforeEdit / etc.), cancel-on-false
+ * semantics, and error-isolation are intentionally deferred to follow-up PRs
+ * and remain tracked in the AC posted on #38.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }], ...extra });
+}
+
+describe('Plugin registry: use()', () => {
+  test('calls install(table, options) exactly once and registers the plugin', () => {
+    const table = makeTable();
+    const install = jest.fn();
+    const plugin = { name: 'audit', version: '1.0.0', install };
+
+    table.use(plugin, { mode: 'silent' });
+
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledWith(table, { mode: 'silent' });
+    expect(table.getPlugins().map(p => p.name)).toContain('audit');
+  });
+
+  test('throws when registering a duplicate name', () => {
+    const table = makeTable();
+    const plugin = { name: 'dup', install: () => {} };
+    table.use(plugin);
+    expect(() => table.use(plugin)).toThrow(/already registered|duplicate/i);
+  });
+
+  test('rejects plugins missing a name', () => {
+    const table = makeTable();
+    expect(() => table.use({ install: () => {} })).toThrow(/name/i);
+  });
+
+  test('install is optional — a hook-only plugin still registers', () => {
+    const table = makeTable();
+    const plugin = { name: 'hooks-only', hooks: {} };
+    expect(() => table.use(plugin)).not.toThrow();
+    expect(table.getPlugins().map(p => p.name)).toContain('hooks-only');
+  });
+});
+
+describe('Plugin registry: unuse()', () => {
+  test('calls uninstall(table) and removes the plugin from the registry', () => {
+    const table = makeTable();
+    const uninstall = jest.fn();
+    table.use({ name: 'p1', install: () => {}, uninstall });
+
+    const removed = table.unuse('p1');
+
+    expect(removed).toBe(true);
+    expect(uninstall).toHaveBeenCalledWith(table);
+    expect(table.getPlugins().map(p => p.name)).not.toContain('p1');
+  });
+
+  test('returns false when no such plugin exists', () => {
+    const table = makeTable();
+    expect(table.unuse('ghost')).toBe(false);
+  });
+
+  test('uninstall is optional — unuse still succeeds and removes it', () => {
+    const table = makeTable();
+    table.use({ name: 'p2', install: () => {} });
+    expect(table.unuse('p2')).toBe(true);
+    expect(table.getPlugins().map(p => p.name)).not.toContain('p2');
+  });
+
+  test('unuse then use of the same name succeeds', () => {
+    const table = makeTable();
+    const plugin = { name: 'cycle', install: () => {} };
+    table.use(plugin);
+    table.unuse('cycle');
+    expect(() => table.use(plugin)).not.toThrow();
+    expect(table.getPlugins().map(p => p.name)).toContain('cycle');
+  });
+});
+
+describe('Plugin registry: getPlugins()', () => {
+  test('returns a defensive copy that does not affect internal state', () => {
+    const table = makeTable();
+    table.use({ name: 'a', install: () => {} });
+    table.use({ name: 'b', install: () => {} });
+
+    const list = table.getPlugins();
+    list.length = 0;
+
+    expect(table.getPlugins().map(p => p.name)).toEqual(['a', 'b']);
+  });
+
+  test('reports name, version, and resolved options', () => {
+    const table = makeTable();
+    table.use({ name: 'p', version: '2.1.0', install: () => {} }, { foo: 1 });
+
+    const [record] = table.getPlugins();
+    expect(record.name).toBe('p');
+    expect(record.version).toBe('2.1.0');
+    expect(record.options).toEqual({ foo: 1 });
+  });
+});
+
+describe('Plugin registry: config.plugins auto-registration', () => {
+  test('plugins listed in config.plugins are registered before first render', () => {
+    const installA = jest.fn();
+    const installB = jest.fn();
+
+    const table = makeTable({
+      plugins: [
+        { name: 'a', install: installA },
+        [{ name: 'b', install: installB }, { count: 5 }]
+      ]
+    });
+
+    expect(installA).toHaveBeenCalled();
+    expect(installB).toHaveBeenCalledWith(table, { count: 5 });
+    expect(table.getPlugins().map(p => p.name)).toEqual(['a', 'b']);
+  });
+
+  test('registration preserves declaration order', () => {
+    const calls = [];
+    const make = name => ({ name, install: () => calls.push(name) });
+
+    makeTable({ plugins: [make('first'), make('second'), make('third')] });
+
+    expect(calls).toEqual(['first', 'second', 'third']);
+  });
+});

--- a/test/plugin-hooks.test.js
+++ b/test/plugin-hooks.test.js
@@ -1,0 +1,158 @@
+/**
+ * Plugin lifecycle hooks (slice 2 of #38, stacked on PR #83 registry).
+ *
+ * Wires beforeRender / afterRender into the render path. Other documented
+ * hooks (beforeLoad / afterLoad / beforeEdit / afterEdit / beforeSort /
+ * afterSort / destroy) are exercisable via _fireHook(name, payload) but
+ * not yet wired into their respective code paths — those land in follow-ups.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id', label: 'ID' }],
+    data: [{ id: 1 }, { id: 2 }],
+    ...extra
+  });
+}
+
+describe('Plugin hooks: render path', () => {
+  test('beforeRender fires when render() is called', () => {
+    const beforeRender = jest.fn();
+    const table = makeTable({ plugins: [{ name: 'p', hooks: { beforeRender } }] });
+
+    beforeRender.mockClear();
+    table.render();
+
+    expect(beforeRender).toHaveBeenCalledTimes(1);
+  });
+
+  test('afterRender fires after render() finishes', () => {
+    const calls = [];
+    const table = makeTable({
+      plugins: [{
+        name: 'p',
+        hooks: {
+          beforeRender: () => calls.push('before'),
+          afterRender: () => calls.push('after')
+        }
+      }]
+    });
+
+    calls.length = 0;
+    table.render();
+
+    expect(calls).toEqual(['before', 'after']);
+  });
+
+  test('multiple plugins on the same hook fire in registration order', () => {
+    const seen = [];
+    const make = name => ({ name, hooks: { beforeRender: () => seen.push(name) } });
+
+    const table = makeTable({ plugins: [make('alpha'), make('beta'), make('gamma')] });
+
+    seen.length = 0;
+    table.render();
+
+    expect(seen).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  test('beforeRender returning false cancels render — afterRender does not fire', () => {
+    const afterRender = jest.fn();
+    const table = makeTable({
+      plugins: [{
+        name: 'cancel',
+        hooks: {
+          beforeRender: () => false,
+          afterRender
+        }
+      }]
+    });
+
+    afterRender.mockClear();
+    document.getElementById('t').innerHTML = '';
+    table.render();
+
+    expect(afterRender).not.toHaveBeenCalled();
+    expect(document.getElementById('t').innerHTML).toBe('');
+  });
+
+  test('afterRender throwing is caught and does not break the table', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const table = makeTable({
+      plugins: [{
+        name: 'noisy',
+        hooks: { afterRender: () => { throw new Error('boom'); } }
+      }]
+    });
+
+    expect(() => table.render()).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test('beforeRender throwing is treated as cancellation', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const afterRender = jest.fn();
+    const table = makeTable({
+      plugins: [{
+        name: 'bad',
+        hooks: {
+          beforeRender: () => { throw new Error('nope'); },
+          afterRender
+        }
+      }]
+    });
+
+    afterRender.mockClear();
+    expect(() => table.render()).not.toThrow();
+    expect(afterRender).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe('Plugin hooks: _fireHook contract', () => {
+  test('_fireHook returns true when no handler exists', () => {
+    const table = makeTable();
+    expect(table._fireHook('arbitraryName', {})).not.toBe(false);
+  });
+
+  test('_fireHook returns false if any handler returns false', () => {
+    const table = makeTable({
+      plugins: [
+        { name: 'a', hooks: { custom: () => true } },
+        { name: 'b', hooks: { custom: () => false } },
+        { name: 'c', hooks: { custom: () => true } }
+      ]
+    });
+    expect(table._fireHook('custom', {})).toBe(false);
+  });
+
+  test('_fireHook passes the payload to each handler', () => {
+    const seen = [];
+    const table = makeTable({
+      plugins: [{ name: 'p', hooks: { custom: payload => seen.push(payload) } }]
+    });
+
+    table._fireHook('custom', { x: 1 });
+
+    expect(seen).toEqual([{ x: 1 }]);
+  });
+});
+
+describe('Plugin hooks: unuse cleans up', () => {
+  test('unuse(name) removes the plugin from hook firing', () => {
+    const beforeRender = jest.fn();
+    const table = makeTable({ plugins: [{ name: 'p', hooks: { beforeRender } }] });
+
+    table.unuse('p');
+    beforeRender.mockClear();
+    table.render();
+
+    expect(beforeRender).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #83 (plugin registry foundation). Adds the lifecycle-hook firing layer. Targets the parent branch so reviewers see only the additive diff; GitHub will retarget at `main` when #83 merges.

- `_fireHook(name, payload)` — iterates plugins in registration order, invokes `plugin.hooks[name]` when defined. Returns `false` if any handler returned `false` or threw. Errors are caught and `console.warn`-ed so a bad plugin cannot break the table.
- `render()` is now wrapped with `beforeRender` / `afterRender`. `beforeRender` returning `false` (or throwing) cancels the render entirely. `afterRender` errors are logged but never propagate.

## Out of scope (still tracked in #38)
- Wiring `beforeLoad` / `afterLoad` into `loadData()`
- Wiring `beforeEdit` / `afterEdit` into the cell-edit code path
- Wiring `beforeSort` / `afterSort` into `sort()`
- Wiring `destroy` into the table teardown
- Plugin-to-plugin dependency resolution

The other documented hook names can already be fired manually via `_fireHook(name, payload)`, so consumer code can opt in today; this PR doesn't pretend the official wiring is done.

## Tests
New file `test/plugin-hooks.test.js` — 10 cases:
- `beforeRender` fires on `render()`.
- `afterRender` fires after `render()` completes (asserted by ordering with `beforeRender`).
- Multiple plugins on the same hook fire in registration order.
- `beforeRender: () => false` cancels the render — `afterRender` does not fire and the DOM stays untouched.
- `afterRender` throwing is caught (no exception escapes) and a warning is logged.
- `beforeRender` throwing is treated as cancellation.
- `_fireHook` returns truthy when no handler matches.
- `_fireHook` returns `false` when any handler returns `false`.
- `_fireHook` passes payload to handlers.
- `unuse(name)` removes the plugin's hooks from future firings.

Combined with the 12 registry tests from PR #83: 22/22 plugin tests green. Full suite: 83/84 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38