### PR TITLE
feat(conditional-formatting): wire matching rules into render path

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -786,6 +786,12 @@ class TableCrafter {
         const tr = document.createElement('tr');
         tr.dataset.rowIndex = actualRowIndex;
 
+        // Apply row-scoped conditional formatting (className-only on tr).
+        if (typeof this.getMatchingRules === 'function') {
+          const rowRules = this.getMatchingRules('*', row, row).filter(r => r.scope === 'row');
+          this._applyConditionalFormatting(tr, rowRules);
+        }
+
         const columnPromises = this.config.columns.map(async (column) => {
           const td = document.createElement('td');
 
@@ -816,6 +822,13 @@ class TableCrafter {
           if (this.config.editable && column.editable && this.hasPermission('edit', row)) {
             td.className = 'tc-editable';
             td.addEventListener('click', (e) => this.startEdit(e, actualRowIndex, column.field));
+          }
+
+          // Apply cell-scoped conditional formatting.
+          if (typeof this.getMatchingRules === 'function') {
+            const cellRules = this.getMatchingRules(column.field, row[column.field], row)
+              .filter(r => r.scope !== 'row');
+            this._applyConditionalFormatting(td, cellRules);
           }
 
           tr.appendChild(td);
@@ -2802,6 +2815,29 @@ class TableCrafter {
     }
     this.config.conditionalFormatting.rules = Array.isArray(rules) ? rules.slice() : [];
     this.render();
+  }
+
+  /**
+   * Apply matching conditional-formatting rules to a target element. Iterates
+   * matches from low to high priority so higher priority style props overwrite
+   * lower; classNames are unioned. Caller controls scope by choosing which
+   * rules to pass in.
+   */
+  _applyConditionalFormatting(target, rules) {
+    if (!target || !Array.isArray(rules) || rules.length === 0) return;
+    // Reverse so iteration runs low → high priority and last write wins.
+    const ordered = rules.slice().reverse();
+    for (const rule of ordered) {
+      if (rule.className) {
+        const classes = Array.isArray(rule.className) ? rule.className : [rule.className];
+        for (const cls of classes) {
+          if (typeof cls === 'string' && cls) target.classList.add(cls);
+        }
+      }
+      if (rule.style && typeof rule.style === 'object') {
+        Object.assign(target.style, rule.style);
+      }
+    }
   }
 
   /**

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -107,6 +107,13 @@ class TableCrafter {
         headers: {},
         authentication: null
       },
+      // Conditional formatting configuration (foundation only — render-loop
+      // wiring, dataBar / colorScale / icon kinds, and aria-label parity
+      // are tracked in #51 follow-ups)
+      conditionalFormatting: {
+        enabled: false,
+        rules: []
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -2705,6 +2712,97 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Conditional formatting — pure rule evaluator.
+   * Accepts either a function predicate `(value, row, ctx) => boolean` or a
+   * declarative `{ op, value }` predicate. Unknown ops resolve to `false`
+   * rather than throw, so a single bad rule cannot break the render.
+   */
+  evaluateRule(rule, value, row) {
+    if (!rule || rule.when == null) return false;
+
+    if (typeof rule.when === 'function') {
+      try {
+        return Boolean(rule.when(value, row, { table: this, field: rule.field }));
+      } catch (e) {
+        console.warn('TableCrafter: conditional-formatting predicate threw', e);
+        return false;
+      }
+    }
+
+    const { op, value: target } = rule.when;
+    switch (op) {
+      case 'gt':       return Number(value) > Number(target);
+      case 'lt':       return Number(value) < Number(target);
+      case 'gte':      return Number(value) >= Number(target);
+      case 'lte':      return Number(value) <= Number(target);
+      case 'eq':       return value === target;
+      case 'neq':      return value !== target;
+      case 'between': {
+        if (!Array.isArray(target) || target.length !== 2) return false;
+        const n = Number(value);
+        return n >= Number(target[0]) && n <= Number(target[1]);
+      }
+      case 'contains': return String(value ?? '').includes(String(target ?? ''));
+      case 'empty':    return value === null || value === undefined || value === '';
+      case 'regex': {
+        try {
+          return new RegExp(target).test(String(value ?? ''));
+        } catch (e) {
+          return false;
+        }
+      }
+      default:         return false;
+    }
+  }
+
+  /**
+   * Return the rules that apply to a given (field, value, row) tuple, sorted
+   * by descending priority (default 0). Wildcard rules (`field: '*'`) match
+   * every field. Returns [] when conditional formatting is disabled.
+   */
+  getMatchingRules(field, value, row) {
+    const cfg = this.config && this.config.conditionalFormatting;
+    if (!cfg || !cfg.enabled || !Array.isArray(cfg.rules)) return [];
+
+    const candidates = cfg.rules.filter(r => r.field === field || r.field === '*');
+    const matches = candidates.filter(r => this.evaluateRule(r, value, row));
+    return matches.slice().sort((a, b) => (b.priority || 0) - (a.priority || 0));
+  }
+
+  /**
+   * Append a conditional-formatting rule and re-render.
+   */
+  addRule(rule) {
+    if (!this.config.conditionalFormatting) {
+      this.config.conditionalFormatting = { enabled: true, rules: [] };
+    }
+    if (!Array.isArray(this.config.conditionalFormatting.rules)) {
+      this.config.conditionalFormatting.rules = [];
+    }
+    this.config.conditionalFormatting.rules.push(rule);
+    this.render();
+    return rule;
+  }
+
+  removeRule(id) {
+    const rules = this.config.conditionalFormatting && this.config.conditionalFormatting.rules;
+    if (!Array.isArray(rules)) return false;
+    const before = rules.length;
+    this.config.conditionalFormatting.rules = rules.filter(r => r.id !== id);
+    const removed = this.config.conditionalFormatting.rules.length < before;
+    if (removed) this.render();
+    return removed;
+  }
+
+  setRules(rules) {
+    if (!this.config.conditionalFormatting) {
+      this.config.conditionalFormatting = { enabled: true, rules: [] };
+    }
+    this.config.conditionalFormatting.rules = Array.isArray(rules) ? rules.slice() : [];
+    this.render();
+  }
 
   /**
    * Set current user context

--- a/test/conditional-formatting-render.test.js
+++ b/test/conditional-formatting-render.test.js
@@ -1,0 +1,110 @@
+/**
+ * Conditional formatting render-loop wiring (slice 2 of #51).
+ * Stacked on PR #80 (rule evaluator + state API).
+ *
+ * Wires getMatchingRules() into the table render so className / style /
+ * scope='row' produce visible DOM mutations. Built-in `kind` shorthands
+ * (dataBar / colorScale / icon) and aria-label parity are deferred to a
+ * follow-up PR.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, status: 'low',  amount: 5 },
+  { id: 2, status: 'mid',  amount: 50 },
+  { id: 3, status: 'high', amount: 95 }
+];
+const columns = [
+  { field: 'id',     label: 'ID' },
+  { field: 'status', label: 'Status' },
+  { field: 'amount', label: 'Amount' }
+];
+
+function makeTable(rules = []) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns,
+    conditionalFormatting: { enabled: true, rules }
+  });
+}
+
+describe('Conditional formatting: cell-scope className', () => {
+  test('matching cells receive the rule className; non-matching do not', () => {
+    const table = makeTable([
+      { id: 'r1', field: 'amount', when: { op: 'lt', value: 10 }, className: 'cell-low', scope: 'cell' }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="amount"]');
+    expect(cells[0].classList.contains('cell-low')).toBe(true);
+    expect(cells[1].classList.contains('cell-low')).toBe(false);
+    expect(cells[2].classList.contains('cell-low')).toBe(false);
+  });
+
+  test('className may be an array — all entries are added', () => {
+    const table = makeTable([
+      { id: 'r1', field: 'amount', when: { op: 'gt', value: 90 }, className: ['hot', 'flash'] }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="amount"]');
+    expect(cells[2].classList.contains('hot')).toBe(true);
+    expect(cells[2].classList.contains('flash')).toBe(true);
+  });
+});
+
+describe('Conditional formatting: cell-scope inline style', () => {
+  test('matching cells receive the rule style', () => {
+    const table = makeTable([
+      { id: 'r1', field: 'amount', when: { op: 'gt', value: 50 }, style: { backgroundColor: 'red' } }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="amount"]');
+    expect(cells[2].style.backgroundColor).toBe('red');
+    expect(cells[1].style.backgroundColor).toBe('');
+  });
+
+  test('multiple rules merge — higher priority wins on conflicting style props', () => {
+    const table = makeTable([
+      { id: 'low-pri',  field: 'amount', when: { op: 'gt', value: 10 }, style: { color: 'blue' }, priority: 1 },
+      { id: 'high-pri', field: 'amount', when: { op: 'gt', value: 10 }, style: { color: 'green' }, priority: 5 }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="amount"]');
+    expect(cells[1].style.color).toBe('green'); // amount=50 matches both, higher priority wins
+  });
+});
+
+describe('Conditional formatting: row scope', () => {
+  test('scope: "row" applies className to the entire <tr>', () => {
+    const table = makeTable([
+      { id: 'flag-low', field: '*', when: row => row.amount < 10, className: 'row-low', scope: 'row' }
+    ]);
+    table.render();
+
+    const rows = document.querySelectorAll('tbody tr');
+    expect(rows[0].classList.contains('row-low')).toBe(true);
+    expect(rows[1].classList.contains('row-low')).toBe(false);
+  });
+});
+
+describe('Conditional formatting: disabled = no-op', () => {
+  test('when conditionalFormatting.enabled is false, nothing is added', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data,
+      columns,
+      conditionalFormatting: {
+        enabled: false,
+        rules: [{ id: 'x', field: 'amount', when: () => true, className: 'should-not-appear' }]
+      }
+    });
+    table.render();
+
+    expect(document.querySelector('.should-not-appear')).toBeNull();
+  });
+});

--- a/test/conditional-formatting.test.js
+++ b/test/conditional-formatting.test.js
@@ -1,0 +1,143 @@
+/**
+ * Conditional formatting foundation (slice of #51).
+ *
+ * This PR lands only:
+ *   - the config.conditionalFormatting surface
+ *   - addRule / removeRule / setRules public API
+ *   - evaluateRule(rule, value, row) pure evaluator (function + core ops)
+ *   - getMatchingRules(field, value, row) lookup helper
+ *
+ * Render-loop wiring (className / style / dataBar / colorScale / aria-label)
+ * is intentionally deferred to follow-up PRs and remains tracked in #51.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'value', label: 'Value' }],
+    data: [{ value: 1 }, { value: 5 }, { value: 10 }],
+    ...extra
+  });
+}
+
+describe('Conditional formatting: evaluateRule', () => {
+  test('function predicate is invoked with (value, row, ctx)', () => {
+    const table = makeTable();
+    const fn = jest.fn(() => true);
+    const row = { value: 7 };
+    expect(table.evaluateRule({ id: 'r1', field: 'value', when: fn }, 7, row)).toBe(true);
+    expect(fn).toHaveBeenCalledWith(7, row, expect.any(Object));
+  });
+
+  test('declarative gt / lt / eq / neq', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'gt', value: 5 } }, 6)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'gt', value: 5 } }, 5)).toBe(false);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'lt', value: 5 } }, 4)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'eq', value: 'a' } }, 'a')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'neq', value: 'a' } }, 'b')).toBe(true);
+  });
+
+  test('declarative between / contains / empty', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'between', value: [1, 10] } }, 5)).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'between', value: [1, 10] } }, 11)).toBe(false);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'contains', value: 'oo' } }, 'foobar')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'empty' } }, '')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'empty' } }, 'x')).toBe(false);
+  });
+
+  test('declarative regex', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'regex', value: '^foo' } }, 'foobar')).toBe(true);
+    expect(t.evaluateRule({ field: 'value', when: { op: 'regex', value: '^foo' } }, 'barfoo')).toBe(false);
+  });
+
+  test('returns false for unknown op without throwing', () => {
+    const t = makeTable();
+    expect(t.evaluateRule({ field: 'value', when: { op: 'xyz', value: 5 } }, 5)).toBe(false);
+  });
+});
+
+describe('Conditional formatting: rule state API', () => {
+  test('addRule appends, getMatchingRules returns matches in priority order', () => {
+    const table = makeTable({
+      conditionalFormatting: { enabled: true, rules: [] }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.addRule({ id: 'low', field: 'value', when: { op: 'lt', value: 3 }, className: 'low', priority: 0 });
+    table.addRule({ id: 'critical', field: 'value', when: { op: 'lt', value: 2 }, className: 'critical', priority: 5 });
+    table.addRule({ id: 'high', field: 'value', when: { op: 'gt', value: 100 }, className: 'high', priority: 0 });
+
+    const matches = table.getMatchingRules('value', 1, { value: 1 });
+    expect(matches.map(r => r.id)).toEqual(['critical', 'low']); // higher priority first
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('removeRule removes by id and re-renders', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [
+          { id: 'r1', field: 'value', when: () => true, className: 'a' },
+          { id: 'r2', field: 'value', when: () => true, className: 'b' }
+        ]
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.removeRule('r1');
+
+    expect(table.config.conditionalFormatting.rules.map(r => r.id)).toEqual(['r2']);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('setRules replaces the rule list and re-renders', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{ id: 'old', field: 'value', when: () => true }]
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.setRules([
+      { id: 'new1', field: 'value', when: () => true },
+      { id: 'new2', field: 'value', when: () => true }
+    ]);
+
+    expect(table.config.conditionalFormatting.rules.map(r => r.id)).toEqual(['new1', 'new2']);
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('getMatchingRules returns [] when conditionalFormatting is disabled', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: false,
+        rules: [{ id: 'r1', field: 'value', when: () => true }]
+      }
+    });
+    expect(table.getMatchingRules('value', 1, { value: 1 })).toEqual([]);
+  });
+
+  test('getMatchingRules respects field — wildcard "*" rules match every field', () => {
+    const table = makeTable({
+      conditionalFormatting: {
+        enabled: true,
+        rules: [
+          { id: 'specific', field: 'value', when: () => true, scope: 'cell' },
+          { id: 'wildcard', field: '*', when: () => true, scope: 'row' }
+        ]
+      }
+    });
+
+    const matches = table.getMatchingRules('value', 1, { value: 1 });
+    const otherField = table.getMatchingRules('something_else', 1, { value: 1 });
+
+    expect(matches.map(r => r.id).sort()).toEqual(['specific', 'wildcard']);
+    expect(otherField.map(r => r.id)).toEqual(['wildcard']);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #80 (rule evaluator + state API). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #80 merges.

Wires `getMatchingRules()` into `renderTable()`:

- `_applyConditionalFormatting(target, rules)` — unions classNames (string or array supported) and merges styles, applying low → high priority so the highest-priority style props win on conflict.
- Cell loop: calls `getMatchingRules(field, value, row)`, filters out `scope: 'row'` rules, applies the rest to the `<td>`.
- Row loop: calls `getMatchingRules('*', row, row)`, keeps `scope: 'row'` rules, applies their classNames to the `<tr>`.

## Out of scope (still tracked in #51)
- `kind: 'dataBar'` — width % `::after` pseudo-element bar
- `kind: 'colorScale'` — interpolated background colour between min/mid/max
- `kind: 'icon'` — leading icon prefix for predicate matches
- `aria-label` parity for visual-only cues (`kind: 'colorScale'` cells)
- Performance benchmark (1000 × 5 rules under 50ms)

## Tests
New file `test/conditional-formatting-render.test.js` — 6 cases:
- Cell-scope className applied only to matching cells
- className may be an array
- Cell-scope inline style applied to matching cells
- Multiple cell rules merge — higher priority wins on conflicting style props
- `scope: 'row'` className applied to the entire `<tr>`
- Disabled config produces no DOM mutations

Combined with the 10 evaluator tests from PR #80: 16/16 cond-format tests green. Full suite: 77/78 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #51