### PR TITLE
feat(export): downloadExport(format, filename?) browser-download helper

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2063,6 +2063,35 @@ class TableCrafter {
   }
 
   /**
+   * Format-aware browser download. Resolves once the link has been clicked,
+   * or rejects with the same error exportData would surface (e.g. xlsx not
+   * yet available, unsupported format). On reject, no download is triggered.
+   */
+  async downloadExport(format, filename) {
+    const content = await this.exportData(format);
+
+    const mime = format === 'json'
+      ? 'application/json;charset=utf-8;'
+      : 'text/csv;charset=utf-8;';
+    const blob = (content instanceof Blob) ? content : new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename || this._exportFilename(format);
+    link.click();
+
+    URL.revokeObjectURL(url);
+  }
+
+  _exportFilename(format) {
+    const configured = this.config.exportFilename || 'table-export';
+    // Strip an existing extension and append the format-appropriate one.
+    const base = String(configured).replace(/\.[^./\\]+$/, '');
+    return `${base}.${format}`;
+  }
+
+  /**
    * Download CSV file
    */
   downloadCSV() {

--- a/test/download-export.test.js
+++ b/test/download-export.test.js
@@ -1,0 +1,121 @@
+/**
+ * downloadExport(format, filename?) — slice 2 of #46.
+ * Stacked on PR #79 (exportData dispatcher + JSON output).
+ *
+ * xlsx and pdf paths still throw the not-yet-available error from PR #79;
+ * downloadExport surfaces those as a rejected promise without triggering
+ * a download.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }];
+const columns = [{ field: 'id', label: 'ID' }, { field: 'name', label: 'Name' }];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns, ...extra });
+}
+
+function spyDownloadMechanism() {
+  const created = [];
+  const revoked = [];
+  const clicks = [];
+
+  const origCreateObjectURL = URL.createObjectURL;
+  const origRevokeObjectURL = URL.revokeObjectURL;
+
+  URL.createObjectURL = blob => {
+    created.push(blob);
+    return 'blob:mock-' + created.length;
+  };
+  URL.revokeObjectURL = url => revoked.push(url);
+
+  const origCreateElement = document.createElement.bind(document);
+  document.createElement = tagName => {
+    const el = origCreateElement(tagName);
+    if (tagName === 'a') {
+      el.click = () => clicks.push({ href: el.href, download: el.download });
+    }
+    return el;
+  };
+
+  return {
+    created, revoked, clicks,
+    restore() {
+      URL.createObjectURL = origCreateObjectURL;
+      URL.revokeObjectURL = origRevokeObjectURL;
+      document.createElement = origCreateElement;
+    }
+  };
+}
+
+describe('downloadExport(format, filename?)', () => {
+  test('csv path triggers a download with the configured filename', async () => {
+    const table = makeTable({ exportFilename: 'my-table.csv' });
+    const spy = spyDownloadMechanism();
+
+    await table.downloadExport('csv');
+
+    expect(spy.clicks).toHaveLength(1);
+    expect(spy.clicks[0].download).toBe('my-table.csv');
+    expect(spy.created).toHaveLength(1);
+    expect(spy.revoked).toHaveLength(1);
+
+    spy.restore();
+  });
+
+  test('json path triggers a download with .json extension when no filename given', async () => {
+    const table = makeTable({ exportFilename: 'my-table.csv' });
+    const spy = spyDownloadMechanism();
+
+    await table.downloadExport('json');
+
+    expect(spy.clicks).toHaveLength(1);
+    expect(spy.clicks[0].download).toMatch(/\.json$/);
+
+    spy.restore();
+  });
+
+  test('explicit filename argument overrides the configured default', async () => {
+    const table = makeTable({ exportFilename: 'default.csv' });
+    const spy = spyDownloadMechanism();
+
+    await table.downloadExport('json', 'custom-name.json');
+
+    expect(spy.clicks[0].download).toBe('custom-name.json');
+
+    spy.restore();
+  });
+
+  test('xlsx rejects without triggering a download', async () => {
+    const table = makeTable();
+    const spy = spyDownloadMechanism();
+
+    await expect(table.downloadExport('xlsx')).rejects.toThrow(/xlsx|not available/i);
+    expect(spy.clicks).toHaveLength(0);
+    expect(spy.created).toHaveLength(0);
+
+    spy.restore();
+  });
+
+  test('pdf rejects without triggering a download', async () => {
+    const table = makeTable();
+    const spy = spyDownloadMechanism();
+
+    await expect(table.downloadExport('pdf')).rejects.toThrow(/pdf|not available/i);
+    expect(spy.clicks).toHaveLength(0);
+
+    spy.restore();
+  });
+
+  test('unsupported format rejects without triggering a download', async () => {
+    const table = makeTable();
+    const spy = spyDownloadMechanism();
+
+    await expect(table.downloadExport('zip')).rejects.toThrow(/unsupported|format/i);
+    expect(spy.clicks).toHaveLength(0);
+
+    spy.restore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #79 (exportData dispatcher + JSON output). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #79 merges.

- `downloadExport(format, filename?)` — awaits `exportData(format)`, wraps the result in a `Blob`, creates an object URL, triggers an anchor click, then revokes the URL.
- Filename defaults to the configured `exportFilename` with the extension swapped to match the format (e.g. `table-export.csv` → `table-export.json`).
- `xlsx` / `pdf` / unsupported formats reject without triggering any download — the error from `exportData` propagates unchanged.

## Out of scope (still tracked in #46)
- xlsx via lazy `xlsx` peer-dep import
- pdf via lazy `jspdf` + `jspdf-autotable`
- Multi-format UI dropdown in `renderExportControls()`

## Tests
New file `test/download-export.test.js` — 6 cases:
- `csv` triggers a download with the configured filename.
- `json` swaps the extension to `.json` when no explicit filename is given.
- Explicit `filename` arg overrides the configured default.
- `xlsx` rejects without triggering a download.
- `pdf` rejects without triggering a download.
- Unsupported format rejects without triggering a download.

Combined with the 7 dispatcher tests from PR #79: 13/13 export tests green. Full suite: 74/75 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #46