### PR TITLE
feat(search): parseQuery() — search grammar parser foundation

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3122,6 +3122,132 @@ class TableCrafter {
   }
 
   /**
+   * Parse a search query string into a normalised AST.
+   *
+   * Supports: whitespace AND, OR (case-insensitive), -negation,
+   * "quoted phrase", field:value (value may be quoted).
+   *
+   * Comparison operators (>, <, =), regex literals, and wildcards are
+   * tracked for follow-up PRs in #59.
+   *
+   * AST node shapes:
+   *   { type: 'and',    children: Node[] }
+   *   { type: 'or',     children: Node[] }
+   *   { type: 'not',    child: Node }
+   *   { type: 'term',   value: string }
+   *   { type: 'phrase', value: string }
+   *   { type: 'field',  field: string, op: 'eq', value: string }
+   */
+  parseQuery(input) {
+    const tokens = this._tokenizeQuery(String(input == null ? '' : input));
+    const children = [];
+    let i = 0;
+    while (i < tokens.length) {
+      const tok = tokens[i];
+      if (tok.type === 'or') {
+        const prev = children.pop();
+        i++;
+        if (i >= tokens.length) {
+          if (prev) children.push(prev);
+          break;
+        }
+        const consumed = this._consumeQueryNode(tokens, i);
+        i = consumed.next;
+        const orNode = (prev && prev.type === 'or')
+          ? { type: 'or', children: [...prev.children, consumed.node] }
+          : { type: 'or', children: [prev || { type: 'term', value: '' }, consumed.node] };
+        children.push(orNode);
+      } else {
+        const consumed = this._consumeQueryNode(tokens, i);
+        i = consumed.next;
+        children.push(consumed.node);
+      }
+    }
+    return { type: 'and', children };
+  }
+
+  _consumeQueryNode(tokens, i) {
+    const tok = tokens[i];
+    if (tok.type === 'not') {
+      if (i + 1 >= tokens.length) {
+        return { node: { type: 'term', value: '' }, next: i + 1 };
+      }
+      const inner = this._consumeQueryNode(tokens, i + 1);
+      return { node: { type: 'not', child: inner.node }, next: inner.next };
+    }
+    if (tok.type === 'phrase') {
+      return { node: { type: 'phrase', value: tok.value }, next: i + 1 };
+    }
+    if (tok.type === 'field') {
+      return {
+        node: { type: 'field', field: tok.field, op: 'eq', value: tok.value },
+        next: i + 1
+      };
+    }
+    return { node: { type: 'term', value: tok.value }, next: i + 1 };
+  }
+
+  _tokenizeQuery(s) {
+    const tokens = [];
+    let i = 0;
+
+    const readQuoted = startIdx => {
+      const end = s.indexOf('"', startIdx + 1);
+      if (end === -1) return { value: s.slice(startIdx + 1), next: s.length };
+      return { value: s.slice(startIdx + 1, end), next: end + 1 };
+    };
+
+    while (i < s.length) {
+      const ch = s[i];
+
+      if (/\s/.test(ch)) { i++; continue; }
+
+      if (ch === '-' && i + 1 < s.length && !/\s/.test(s[i + 1])) {
+        tokens.push({ type: 'not' });
+        i++;
+        continue;
+      }
+
+      if (ch === '"') {
+        const q = readQuoted(i);
+        tokens.push({ type: 'phrase', value: q.value });
+        i = q.next;
+        continue;
+      }
+
+      const wordStart = i;
+      while (i < s.length && !/[\s":]/.test(s[i])) i++;
+      const word = s.slice(wordStart, i);
+
+      if (word.toUpperCase() === 'OR') {
+        tokens.push({ type: 'or' });
+        continue;
+      }
+
+      if (i < s.length && s[i] === ':') {
+        i++; // consume colon
+        let value = '';
+        if (i < s.length && s[i] === '"') {
+          const q = readQuoted(i);
+          value = q.value;
+          i = q.next;
+        } else {
+          const valueStart = i;
+          while (i < s.length && !/\s/.test(s[i])) i++;
+          value = s.slice(valueStart, i);
+        }
+        tokens.push({ type: 'field', field: word, value });
+        continue;
+      }
+
+      if (word.length > 0) {
+        tokens.push({ type: 'term', value: word });
+      }
+    }
+    return tokens;
+  }
+
+  /**
    * Set current user context
    */
   setCurrentUser(user) {

--- a/test/search-grammar.test.js
+++ b/test/search-grammar.test.js
@@ -1,0 +1,160 @@
+/**
+ * parseQuery() — search grammar foundation (slice 1 of #59).
+ *
+ * This PR lands only the parser producing a normalised AST for the basic
+ * grammar: whitespace AND, OR, -negation, "quoted phrase", field:value,
+ * bare terms. Comparison operators (>, <, =), regex literals, wildcards,
+ * the search builder modal, suggestions, and presets are deferred to
+ * follow-up PRs and remain tracked in #59.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }] });
+}
+
+describe('parseQuery: bare terms', () => {
+  test('single bare term', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo')).toEqual({
+      type: 'and',
+      children: [{ type: 'term', value: 'foo' }]
+    });
+  });
+
+  test('whitespace separates AND-combined terms', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo bar baz')).toEqual({
+      type: 'and',
+      children: [
+        { type: 'term', value: 'foo' },
+        { type: 'term', value: 'bar' },
+        { type: 'term', value: 'baz' }
+      ]
+    });
+  });
+
+  test('empty query produces an empty AND', () => {
+    const t = makeTable();
+    expect(t.parseQuery('')).toEqual({ type: 'and', children: [] });
+  });
+
+  test('whitespace-only query produces an empty AND', () => {
+    const t = makeTable();
+    expect(t.parseQuery('   ')).toEqual({ type: 'and', children: [] });
+  });
+});
+
+describe('parseQuery: OR', () => {
+  test('OR splits adjacent terms into a disjunction', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo OR bar')).toEqual({
+      type: 'and',
+      children: [
+        {
+          type: 'or',
+          children: [
+            { type: 'term', value: 'foo' },
+            { type: 'term', value: 'bar' }
+          ]
+        }
+      ]
+    });
+  });
+
+  test('case-insensitive: "or" works the same as "OR"', () => {
+    const t = makeTable();
+    const upper = t.parseQuery('foo OR bar');
+    const lower = t.parseQuery('foo or bar');
+    expect(lower).toEqual(upper);
+  });
+});
+
+describe('parseQuery: negation', () => {
+  test('-term wraps a term in a NOT', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-foo')).toEqual({
+      type: 'and',
+      children: [{ type: 'not', child: { type: 'term', value: 'foo' } }]
+    });
+  });
+
+  test('-"phrase" negates a quoted phrase', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-"foo bar"')).toEqual({
+      type: 'and',
+      children: [{ type: 'not', child: { type: 'phrase', value: 'foo bar' } }]
+    });
+  });
+
+  test('-field:value negates a field-scoped match', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-status:archived')).toEqual({
+      type: 'and',
+      children: [{
+        type: 'not',
+        child: { type: 'field', field: 'status', op: 'eq', value: 'archived' }
+      }]
+    });
+  });
+});
+
+describe('parseQuery: quoted phrases', () => {
+  test('quoted phrase becomes a single phrase node', () => {
+    const t = makeTable();
+    expect(t.parseQuery('"foo bar"')).toEqual({
+      type: 'and',
+      children: [{ type: 'phrase', value: 'foo bar' }]
+    });
+  });
+
+  test('quoted phrase preserves internal whitespace', () => {
+    const t = makeTable();
+    expect(t.parseQuery('"  spaced  out  "')).toEqual({
+      type: 'and',
+      children: [{ type: 'phrase', value: '  spaced  out  ' }]
+    });
+  });
+});
+
+describe('parseQuery: field:value', () => {
+  test('simple field:value', () => {
+    const t = makeTable();
+    expect(t.parseQuery('status:open')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'status', op: 'eq', value: 'open' }]
+    });
+  });
+
+  test('field:"quoted value" preserves internal whitespace', () => {
+    const t = makeTable();
+    expect(t.parseQuery('name:"Jane Doe"')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'name', op: 'eq', value: 'Jane Doe' }]
+    });
+  });
+});
+
+describe('parseQuery: combinations', () => {
+  test('mixed AND + OR + negation + field + phrase', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('foo OR bar -baz status:open "exact phrase"');
+    expect(ast).toEqual({
+      type: 'and',
+      children: [
+        {
+          type: 'or',
+          children: [
+            { type: 'term', value: 'foo' },
+            { type: 'term', value: 'bar' }
+          ]
+        },
+        { type: 'not', child: { type: 'term', value: 'baz' } },
+        { type: 'field', field: 'status', op: 'eq', value: 'open' },
+        { type: 'phrase', value: 'exact phrase' }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice of issue #59. Lands a tokeniser + recursive parser that produce a normalised AST for the basic search grammar. Evaluator that filters `this.data`, suggestions, builder modal, and presets are deferred to follow-up PRs so this one stays small.

Supported grammar:
- whitespace = AND
- `OR` (case-insensitive) = disjunction
- `-term` / `-\"phrase\"` / `-field:value` = negation
- `\"quoted phrase\"` = single phrase node (whitespace preserved)
- `field:value` (value may itself be quoted)
- bare terms

AST node shapes:
```js
{ type: 'and',    children: Node[] }
{ type: 'or',     children: Node[] }
{ type: 'not',    child: Node }
{ type: 'term',   value: string }
{ type: 'phrase', value: string }
{ type: 'field',  field, op: 'eq', value }
```

## Out of scope (still tracked in #59)
- Comparison operators (`field:>10`, `field:<=5`, `field:=foo`)
- Regex literals (`field:/regex/i`)
- Wildcards (`gold*`, `wo?d`)
- AST evaluator that filters `this.data`
- `setQuery()` integration with the existing global search input
- Search suggestions dropdown
- Query builder modal UI
- Filter presets API (`config.search.presets`, `savePreset` / `removePreset`)

## Tests
New file `test/search-grammar.test.js` — 14 cases:
- Bare terms (single, multiple, empty, whitespace-only)
- `OR` (uppercase + lowercase)
- `-term`, `-\"phrase\"`, `-field:value` negation
- Quoted phrases (basic + internal whitespace preserved)
- `field:value` (basic + quoted value)
- Mixed AND + OR + negation + field + phrase combination

Full suite: 75/76 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59