### PR TITLE
feat(search): AST evaluator + setQuery() integration

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -1257,8 +1257,12 @@ class TableCrafter {
       return data;
     }
 
-    // Apply global search filter
-    if (this.config.globalSearch && this.searchTerm) {
+    // Apply global search filter. setQuery() routes through the parsed AST;
+    // direct searchTerm assignment continues to use the legacy substring path
+    // for backwards compatibility.
+    if (this._queryAst) {
+      data = data.filter(row => this.evaluateQuery(this._queryAst, row));
+    } else if (this.config.globalSearch && this.searchTerm) {
       const searchLower = this.searchTerm.toLowerCase();
       data = data.filter(row => {
         return Object.values(row).some(val => {
@@ -2749,6 +2753,60 @@ class TableCrafter {
       }
     }
     return { type: 'and', children };
+  }
+
+  /**
+   * Evaluate a parsed AST against a single row.
+   * Substring matching is case-insensitive. Term matches scan all string-
+   * coerced row values; field matches scope to the named column. An empty
+   * AND (the result of an empty query) returns true so empty queries match
+   * every row.
+   */
+  evaluateQuery(node, row) {
+    if (!node || !node.type) return true;
+    switch (node.type) {
+      case 'and':
+        return (node.children || []).every(c => this.evaluateQuery(c, row));
+      case 'or':
+        return (node.children || []).some(c => this.evaluateQuery(c, row));
+      case 'not':
+        return !this.evaluateQuery(node.child, row);
+      case 'term': {
+        const needle = String(node.value || '').toLowerCase();
+        if (!needle) return true;
+        return Object.values(row).some(v => v != null && String(v).toLowerCase().includes(needle));
+      }
+      case 'phrase': {
+        const needle = String(node.value || '').toLowerCase();
+        if (!needle) return true;
+        return Object.values(row).some(v => v != null && String(v).toLowerCase().includes(needle));
+      }
+      case 'field': {
+        const cell = row[node.field];
+        if (cell === undefined || cell === null) return false;
+        const haystack = String(cell).toLowerCase();
+        const needle = String(node.value || '').toLowerCase();
+        return haystack.includes(needle);
+      }
+      default:
+        return true;
+    }
+  }
+
+  /**
+   * Programmatically apply a search query string. Empty / falsy clears the
+   * active query. Triggers a re-render so the filtered set is visible.
+   */
+  setQuery(queryString) {
+    const q = queryString == null ? '' : String(queryString);
+    if (q === '') {
+      this._queryAst = null;
+      this.searchTerm = '';
+    } else {
+      this._queryAst = this.parseQuery(q);
+      this.searchTerm = q;
+    }
+    this.render();
   }
 
   _consumeQueryNode(tokens, i) {

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2707,6 +2707,132 @@ class TableCrafter {
    */
 
   /**
+   * Parse a search query string into a normalised AST.
+   *
+   * Supports: whitespace AND, OR (case-insensitive), -negation,
+   * "quoted phrase", field:value (value may be quoted).
+   *
+   * Comparison operators (>, <, =), regex literals, and wildcards are
+   * tracked for follow-up PRs in #59.
+   *
+   * AST node shapes:
+   *   { type: 'and',    children: Node[] }
+   *   { type: 'or',     children: Node[] }
+   *   { type: 'not',    child: Node }
+   *   { type: 'term',   value: string }
+   *   { type: 'phrase', value: string }
+   *   { type: 'field',  field: string, op: 'eq', value: string }
+   */
+  parseQuery(input) {
+    const tokens = this._tokenizeQuery(String(input == null ? '' : input));
+    const children = [];
+    let i = 0;
+    while (i < tokens.length) {
+      const tok = tokens[i];
+      if (tok.type === 'or') {
+        const prev = children.pop();
+        i++;
+        if (i >= tokens.length) {
+          if (prev) children.push(prev);
+          break;
+        }
+        const consumed = this._consumeQueryNode(tokens, i);
+        i = consumed.next;
+        const orNode = (prev && prev.type === 'or')
+          ? { type: 'or', children: [...prev.children, consumed.node] }
+          : { type: 'or', children: [prev || { type: 'term', value: '' }, consumed.node] };
+        children.push(orNode);
+      } else {
+        const consumed = this._consumeQueryNode(tokens, i);
+        i = consumed.next;
+        children.push(consumed.node);
+      }
+    }
+    return { type: 'and', children };
+  }
+
+  _consumeQueryNode(tokens, i) {
+    const tok = tokens[i];
+    if (tok.type === 'not') {
+      if (i + 1 >= tokens.length) {
+        return { node: { type: 'term', value: '' }, next: i + 1 };
+      }
+      const inner = this._consumeQueryNode(tokens, i + 1);
+      return { node: { type: 'not', child: inner.node }, next: inner.next };
+    }
+    if (tok.type === 'phrase') {
+      return { node: { type: 'phrase', value: tok.value }, next: i + 1 };
+    }
+    if (tok.type === 'field') {
+      return {
+        node: { type: 'field', field: tok.field, op: 'eq', value: tok.value },
+        next: i + 1
+      };
+    }
+    return { node: { type: 'term', value: tok.value }, next: i + 1 };
+  }
+
+  _tokenizeQuery(s) {
+    const tokens = [];
+    let i = 0;
+
+    const readQuoted = startIdx => {
+      const end = s.indexOf('"', startIdx + 1);
+      if (end === -1) return { value: s.slice(startIdx + 1), next: s.length };
+      return { value: s.slice(startIdx + 1, end), next: end + 1 };
+    };
+
+    while (i < s.length) {
+      const ch = s[i];
+
+      if (/\s/.test(ch)) { i++; continue; }
+
+      if (ch === '-' && i + 1 < s.length && !/\s/.test(s[i + 1])) {
+        tokens.push({ type: 'not' });
+        i++;
+        continue;
+      }
+
+      if (ch === '"') {
+        const q = readQuoted(i);
+        tokens.push({ type: 'phrase', value: q.value });
+        i = q.next;
+        continue;
+      }
+
+      const wordStart = i;
+      while (i < s.length && !/[\s":]/.test(s[i])) i++;
+      const word = s.slice(wordStart, i);
+
+      if (word.toUpperCase() === 'OR') {
+        tokens.push({ type: 'or' });
+        continue;
+      }
+
+      if (i < s.length && s[i] === ':') {
+        i++; // consume colon
+        let value = '';
+        if (i < s.length && s[i] === '"') {
+          const q = readQuoted(i);
+          value = q.value;
+          i = q.next;
+        } else {
+          const valueStart = i;
+          while (i < s.length && !/\s/.test(s[i])) i++;
+          value = s.slice(valueStart, i);
+        }
+        tokens.push({ type: 'field', field: word, value });
+        continue;
+      }
+
+      if (word.length > 0) {
+        tokens.push({ type: 'term', value: word });
+      }
+    }
+    return tokens;
+  }
+
+  /**
    * Set current user context
    */
   setCurrentUser(user) {

--- a/test/search-evaluator.test.js
+++ b/test/search-evaluator.test.js
@@ -1,0 +1,110 @@
+/**
+ * AST evaluator + setQuery integration (slice 2 of #59).
+ * Stacked on PR #87 (parseQuery foundation).
+ *
+ * Wires the parsed AST into a row-level predicate and a public setQuery()
+ * method that drives the existing global-search filtering.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, name: 'Alice',   status: 'open',     team: 'core'    },
+  { id: 2, name: 'Bob',     status: 'closed',   team: 'core'    },
+  { id: 3, name: 'Charlie', status: 'open',     team: 'mobile'  },
+  { id: 4, name: 'Dana',    status: 'archived', team: 'mobile'  }
+];
+const columns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' },
+  { field: 'status', label: 'Status' },
+  { field: 'team', label: 'Team' }
+];
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('evaluateQuery: term matching', () => {
+  test('bare term matches case-insensitively across all columns', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('alice');
+    expect(t.evaluateQuery(ast, { id: 1, name: 'Alice', status: 'open' })).toBe(true);
+    expect(t.evaluateQuery(ast, { id: 2, name: 'Bob', status: 'closed' })).toBe(false);
+  });
+
+  test('multiple bare terms are AND-combined', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('alice open');
+    expect(t.evaluateQuery(ast, { name: 'Alice', status: 'open' })).toBe(true);
+    expect(t.evaluateQuery(ast, { name: 'Alice', status: 'closed' })).toBe(false);
+  });
+
+  test('empty query matches every row', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('');
+    expect(t.evaluateQuery(ast, { name: 'anything' })).toBe(true);
+  });
+});
+
+describe('evaluateQuery: OR / NOT / phrase / field', () => {
+  test('OR matches if either branch matches', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('alice OR bob');
+    expect(t.evaluateQuery(ast, { name: 'Alice' })).toBe(true);
+    expect(t.evaluateQuery(ast, { name: 'Bob' })).toBe(true);
+    expect(t.evaluateQuery(ast, { name: 'Charlie' })).toBe(false);
+  });
+
+  test('-term excludes matching rows', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('-archived');
+    expect(t.evaluateQuery(ast, { status: 'open' })).toBe(true);
+    expect(t.evaluateQuery(ast, { status: 'archived' })).toBe(false);
+  });
+
+  test('"quoted phrase" matches as a single substring', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('"foo bar"');
+    expect(t.evaluateQuery(ast, { note: 'lots of foo bar here' })).toBe(true);
+    expect(t.evaluateQuery(ast, { note: 'foo and bar separately' })).toBe(false);
+  });
+
+  test('field:value scopes the match to the named column', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('status:open');
+    expect(t.evaluateQuery(ast, { status: 'open',   name: 'Alice' })).toBe(true);
+    expect(t.evaluateQuery(ast, { status: 'closed', name: 'open'  })).toBe(false);
+  });
+
+  test('field match is case-insensitive', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('status:OPEN');
+    expect(t.evaluateQuery(ast, { status: 'open' })).toBe(true);
+  });
+});
+
+describe('setQuery integration with the existing search filter', () => {
+  test('setQuery applies the parsed query to filter visible rows', () => {
+    const t = makeTable();
+    t.setQuery('mobile');
+    const visible = t.getFilteredData();
+    expect(visible.map(r => r.name).sort()).toEqual(['Charlie', 'Dana']);
+  });
+
+  test('setQuery with field-scoped search narrows further', () => {
+    const t = makeTable();
+    t.setQuery('team:mobile -archived');
+    const visible = t.getFilteredData();
+    expect(visible.map(r => r.name)).toEqual(['Charlie']);
+  });
+
+  test('setQuery("") clears the active query and shows all rows', () => {
+    const t = makeTable();
+    t.setQuery('alice');
+    expect(t.getFilteredData()).toHaveLength(1);
+    t.setQuery('');
+    expect(t.getFilteredData()).toHaveLength(4);
+  });
+});

--- a/test/search-grammar.test.js
+++ b/test/search-grammar.test.js
@@ -1,0 +1,160 @@
+/**
+ * parseQuery() — search grammar foundation (slice 1 of #59).
+ *
+ * This PR lands only the parser producing a normalised AST for the basic
+ * grammar: whitespace AND, OR, -negation, "quoted phrase", field:value,
+ * bare terms. Comparison operators (>, <, =), regex literals, wildcards,
+ * the search builder modal, suggestions, and presets are deferred to
+ * follow-up PRs and remain tracked in #59.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }] });
+}
+
+describe('parseQuery: bare terms', () => {
+  test('single bare term', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo')).toEqual({
+      type: 'and',
+      children: [{ type: 'term', value: 'foo' }]
+    });
+  });
+
+  test('whitespace separates AND-combined terms', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo bar baz')).toEqual({
+      type: 'and',
+      children: [
+        { type: 'term', value: 'foo' },
+        { type: 'term', value: 'bar' },
+        { type: 'term', value: 'baz' }
+      ]
+    });
+  });
+
+  test('empty query produces an empty AND', () => {
+    const t = makeTable();
+    expect(t.parseQuery('')).toEqual({ type: 'and', children: [] });
+  });
+
+  test('whitespace-only query produces an empty AND', () => {
+    const t = makeTable();
+    expect(t.parseQuery('   ')).toEqual({ type: 'and', children: [] });
+  });
+});
+
+describe('parseQuery: OR', () => {
+  test('OR splits adjacent terms into a disjunction', () => {
+    const t = makeTable();
+    expect(t.parseQuery('foo OR bar')).toEqual({
+      type: 'and',
+      children: [
+        {
+          type: 'or',
+          children: [
+            { type: 'term', value: 'foo' },
+            { type: 'term', value: 'bar' }
+          ]
+        }
+      ]
+    });
+  });
+
+  test('case-insensitive: "or" works the same as "OR"', () => {
+    const t = makeTable();
+    const upper = t.parseQuery('foo OR bar');
+    const lower = t.parseQuery('foo or bar');
+    expect(lower).toEqual(upper);
+  });
+});
+
+describe('parseQuery: negation', () => {
+  test('-term wraps a term in a NOT', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-foo')).toEqual({
+      type: 'and',
+      children: [{ type: 'not', child: { type: 'term', value: 'foo' } }]
+    });
+  });
+
+  test('-"phrase" negates a quoted phrase', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-"foo bar"')).toEqual({
+      type: 'and',
+      children: [{ type: 'not', child: { type: 'phrase', value: 'foo bar' } }]
+    });
+  });
+
+  test('-field:value negates a field-scoped match', () => {
+    const t = makeTable();
+    expect(t.parseQuery('-status:archived')).toEqual({
+      type: 'and',
+      children: [{
+        type: 'not',
+        child: { type: 'field', field: 'status', op: 'eq', value: 'archived' }
+      }]
+    });
+  });
+});
+
+describe('parseQuery: quoted phrases', () => {
+  test('quoted phrase becomes a single phrase node', () => {
+    const t = makeTable();
+    expect(t.parseQuery('"foo bar"')).toEqual({
+      type: 'and',
+      children: [{ type: 'phrase', value: 'foo bar' }]
+    });
+  });
+
+  test('quoted phrase preserves internal whitespace', () => {
+    const t = makeTable();
+    expect(t.parseQuery('"  spaced  out  "')).toEqual({
+      type: 'and',
+      children: [{ type: 'phrase', value: '  spaced  out  ' }]
+    });
+  });
+});
+
+describe('parseQuery: field:value', () => {
+  test('simple field:value', () => {
+    const t = makeTable();
+    expect(t.parseQuery('status:open')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'status', op: 'eq', value: 'open' }]
+    });
+  });
+
+  test('field:"quoted value" preserves internal whitespace', () => {
+    const t = makeTable();
+    expect(t.parseQuery('name:"Jane Doe"')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'name', op: 'eq', value: 'Jane Doe' }]
+    });
+  });
+});
+
+describe('parseQuery: combinations', () => {
+  test('mixed AND + OR + negation + field + phrase', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('foo OR bar -baz status:open "exact phrase"');
+    expect(ast).toEqual({
+      type: 'and',
+      children: [
+        {
+          type: 'or',
+          children: [
+            { type: 'term', value: 'foo' },
+            { type: 'term', value: 'bar' }
+          ]
+        },
+        { type: 'not', child: { type: 'term', value: 'baz' } },
+        { type: 'field', field: 'status', op: 'eq', value: 'open' },
+        { type: 'phrase', value: 'exact phrase' }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #87 (parseQuery foundation). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #87 merges.

- `evaluateQuery(ast, row)` — recursive walk over `and / or / not / term / phrase / field` nodes. Term and phrase scan all string-coerced row values (case-insensitive substring). Field nodes scope the match to the named column. Empty AND matches every row.
- `setQuery(queryString)` — parses, stashes the AST on `_queryAst`, mirrors the raw string into `searchTerm`, and re-renders. Empty input clears the query.
- `getFilteredData()` prefers `_queryAst` when present and falls back to the legacy substring path when only `searchTerm` is set, so existing consumers that mutate `searchTerm` directly keep working.

## Out of scope (still tracked in #59)
- Comparison operators (`field:>10`, `field:<=5`, `field:=foo`)
- Regex literals (`field:/regex/i`)
- Wildcards (`gold*`, `wo?d`)
- Suggestions dropdown (`config.search.suggestions`)
- Query builder modal UI (`config.search.builder`)
- Presets API (`config.search.presets`, `savePreset` / `removePreset`)

## Tests
New file `test/search-evaluator.test.js` — 11 cases:
- Bare-term match across all columns, case-insensitive
- Multi-term AND
- Empty query matches every row
- OR matches if either branch matches
- `-term` excludes
- `\"quoted phrase\"` matches as a single substring
- `field:value` scopes to the named column
- Field match is case-insensitive
- `setQuery` filters visible rows
- `setQuery` with `field:value -term` narrows further
- `setQuery('')` clears

Combined with the 14 parser tests from PR #87: 25/25 search tests green. Full suite: 86/87 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59