### PR TITLE
feat(search): comparison operators (>, <, >=, <=, =) on field queries

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2784,6 +2784,19 @@ class TableCrafter {
       case 'field': {
         const cell = row[node.field];
         if (cell === undefined || cell === null) return false;
+        const op = node.op || 'eq';
+        if (op === 'eq_strict') {
+          return String(cell) === String(node.value);
+        }
+        if (op === 'gt' || op === 'lt' || op === 'gte' || op === 'lte') {
+          const cellNum = Number(cell);
+          const valNum = Number(node.value);
+          if (Number.isNaN(cellNum) || Number.isNaN(valNum)) return false;
+          if (op === 'gt')  return cellNum >  valNum;
+          if (op === 'lt')  return cellNum <  valNum;
+          if (op === 'gte') return cellNum >= valNum;
+          if (op === 'lte') return cellNum <= valNum;
+        }
         const haystack = String(cell).toLowerCase();
         const needle = String(node.value || '').toLowerCase();
         return haystack.includes(needle);
@@ -2823,7 +2836,7 @@ class TableCrafter {
     }
     if (tok.type === 'field') {
       return {
-        node: { type: 'field', field: tok.field, op: 'eq', value: tok.value },
+        node: { type: 'field', field: tok.field, op: tok.op || 'eq', value: tok.value },
         next: i + 1
       };
     }
@@ -2869,6 +2882,13 @@ class TableCrafter {
 
       if (i < s.length && s[i] === ':') {
         i++; // consume colon
+        let op = 'eq';
+        if (s[i] === '>' && s[i + 1] === '=') { op = 'gte'; i += 2; }
+        else if (s[i] === '<' && s[i + 1] === '=') { op = 'lte'; i += 2; }
+        else if (s[i] === '>') { op = 'gt'; i += 1; }
+        else if (s[i] === '<') { op = 'lt'; i += 1; }
+        else if (s[i] === '=') { op = 'eq_strict'; i += 1; }
+
         let value = '';
         if (i < s.length && s[i] === '"') {
           const q = readQuoted(i);
@@ -2879,7 +2899,7 @@ class TableCrafter {
           while (i < s.length && !/\s/.test(s[i])) i++;
           value = s.slice(valueStart, i);
         }
-        tokens.push({ type: 'field', field: word, value });
+        tokens.push({ type: 'field', field: word, op, value });
         continue;
       }
 

--- a/test/search-comparisons.test.js
+++ b/test/search-comparisons.test.js
@@ -1,0 +1,118 @@
+/**
+ * Search grammar — comparison operators on field values (slice 3 of #59).
+ * Stacked on PR #88 (AST evaluator + setQuery integration).
+ *
+ * Lands `field:>N`, `field:<N`, `field:>=N`, `field:<=N`, and `field:=value`.
+ * Regex literals (`field:/regex/i`) and wildcards (`gold*`, `wo?d`) are still
+ * deferred to follow-up PRs.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, age: 18, role: 'guest'  },
+  { id: 2, age: 25, role: 'editor' },
+  { id: 3, age: 40, role: 'admin'  },
+  { id: 4, age: 65, role: 'admin'  }
+];
+const columns = [
+  { field: 'id', label: 'ID' },
+  { field: 'age', label: 'Age' },
+  { field: 'role', label: 'Role' }
+];
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('parseQuery: comparison operators', () => {
+  test('field:>N parses with op gt', () => {
+    const t = makeTable();
+    expect(t.parseQuery('age:>30')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'age', op: 'gt', value: '30' }]
+    });
+  });
+
+  test('field:<N parses with op lt', () => {
+    const t = makeTable();
+    expect(t.parseQuery('age:<30')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'age', op: 'lt', value: '30' }]
+    });
+  });
+
+  test('field:>=N and field:<=N parse with gte / lte', () => {
+    const t = makeTable();
+    expect(t.parseQuery('age:>=18')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'age', op: 'gte', value: '18' }]
+    });
+    expect(t.parseQuery('age:<=65')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'age', op: 'lte', value: '65' }]
+    });
+  });
+
+  test('field:=value parses as a strict-equals match', () => {
+    const t = makeTable();
+    expect(t.parseQuery('role:=admin')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'role', op: 'eq_strict', value: 'admin' }]
+    });
+  });
+});
+
+describe('evaluateQuery: comparison operators', () => {
+  test('age:>30 matches rows where age > 30', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('age:>30');
+    expect(t.evaluateQuery(ast, { age: 40 })).toBe(true);
+    expect(t.evaluateQuery(ast, { age: 30 })).toBe(false);
+    expect(t.evaluateQuery(ast, { age: 18 })).toBe(false);
+  });
+
+  test('age:>=30 includes the boundary', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('age:>=30');
+    expect(t.evaluateQuery(ast, { age: 30 })).toBe(true);
+    expect(t.evaluateQuery(ast, { age: 29 })).toBe(false);
+  });
+
+  test('age:<=30 includes the boundary', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('age:<=30');
+    expect(t.evaluateQuery(ast, { age: 30 })).toBe(true);
+    expect(t.evaluateQuery(ast, { age: 31 })).toBe(false);
+  });
+
+  test('role:=admin matches strict equality (not substring)', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('role:=admin');
+    expect(t.evaluateQuery(ast, { role: 'admin' })).toBe(true);
+    expect(t.evaluateQuery(ast, { role: 'admins' })).toBe(false);
+    expect(t.evaluateQuery(ast, { role: 'super-admin' })).toBe(false);
+  });
+
+  test('numeric comparisons are skipped (false) for non-numeric cells', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('age:>30');
+    expect(t.evaluateQuery(ast, { age: 'unknown' })).toBe(false);
+    expect(t.evaluateQuery(ast, { age: null })).toBe(false);
+  });
+});
+
+describe('setQuery integration with comparison operators', () => {
+  test('age:>30 narrows to rows where age > 30', () => {
+    const t = makeTable();
+    t.setQuery('age:>30');
+    expect(t.getFilteredData().map(r => r.id).sort()).toEqual([3, 4]);
+  });
+
+  test('role:=admin -age:>=65 admins under 65', () => {
+    const t = makeTable();
+    t.setQuery('role:=admin -age:>=65');
+    expect(t.getFilteredData().map(r => r.id)).toEqual([3]);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #88 (AST evaluator + `setQuery`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #88 merges.

Recognised forms after `field:`:

| Form        | AST `op`     | Semantics                              |
|-------------|--------------|----------------------------------------|
| `field:>N`  | `gt`         | numeric strict greater-than            |
| `field:<N`  | `lt`         | numeric strict less-than               |
| `field:>=N` | `gte`        | numeric greater-or-equal               |
| `field:<=N` | `lte`        | numeric less-or-equal                  |
| `field:=v`  | `eq_strict`  | strict string equality (no substring)  |
| `field:v`   | `eq` (existing)| case-insensitive substring (unchanged) |

Numeric ops coerce both sides via `Number(...)` and return false when either side is NaN — non-numeric cells do not silently match a numeric query.

## Out of scope (still tracked in #59)
- Regex literals (`field:/regex/i`)
- Wildcards (`gold*`, `wo?d`)
- Suggestions dropdown, builder modal, presets API
- Server-side query delegation when an API is configured

## Tests
New file `test/search-comparisons.test.js` — 11 cases:
- Each operator parses with the right AST `op`
- `>=` / `<=` boundary inclusion
- `=` strict equality (rejects `admins` and `super-admin` against `=admin`)
- Non-numeric cells return false for numeric ops
- `setQuery('age:>30')` filter integration
- `setQuery('role:=admin -age:>=65')` mixed query

Combined: 36/36 search tests green (14 parser + 11 evaluator + 11 comparisons). Full suite: 97/98 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59