### PR TITLE
feat(search): wildcard substitution (* and ?) in term and field:eq values

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2772,8 +2772,13 @@ class TableCrafter {
       case 'not':
         return !this.evaluateQuery(node.child, row);
       case 'term': {
-        const needle = String(node.value || '').toLowerCase();
-        if (!needle) return true;
+        const raw = String(node.value || '');
+        if (!raw) return true;
+        const re = this._wildcardRegex(raw);
+        if (re) {
+          return Object.values(row).some(v => v != null && re.test(String(v)));
+        }
+        const needle = raw.toLowerCase();
         return Object.values(row).some(v => v != null && String(v).toLowerCase().includes(needle));
       }
       case 'phrase': {
@@ -2797,12 +2802,36 @@ class TableCrafter {
           if (op === 'gte') return cellNum >= valNum;
           if (op === 'lte') return cellNum <= valNum;
         }
+        const re = this._wildcardRegex(String(node.value || ''));
+        if (re) return re.test(String(cell));
         const haystack = String(cell).toLowerCase();
         const needle = String(node.value || '').toLowerCase();
         return haystack.includes(needle);
       }
       default:
         return true;
+    }
+  }
+
+  /**
+   * Build a case-insensitive anchored regex from a wildcard expression.
+   * `*` -> `.*`, `?` -> `.`, all other regex metacharacters are escaped.
+   * Returns null when the input contains no wildcard characters so the
+   * caller can fall back to a plain substring match.
+   */
+  _wildcardRegex(value) {
+    if (!/[*?]/.test(value)) return null;
+    let pattern = '^';
+    for (const ch of value) {
+      if (ch === '*') pattern += '.*';
+      else if (ch === '?') pattern += '.';
+      else pattern += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+    pattern += '$';
+    try {
+      return new RegExp(pattern, 'i');
+    } catch (e) {
+      return null;
     }
   }
 

--- a/test/search-wildcards.test.js
+++ b/test/search-wildcards.test.js
@@ -1,0 +1,95 @@
+/**
+ * Search grammar — wildcard substitution in term + field:eq values.
+ * Slice 4 of #59. Stacked on PR #89 (comparison operators).
+ *
+ * Adds support for `*` (zero-or-more) and `?` (single char) inside terms and
+ * the value of a `field:eq` query. Quoted phrases continue to be literal.
+ * Regex literals (`field:/regex/i`) are still tracked as a follow-up.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, name: 'gold' },
+  { id: 2, name: 'golden' },
+  { id: 3, name: 'goldfish' },
+  { id: 4, name: 'silver' },
+  { id: 5, name: 'word' },
+  { id: 6, name: 'wood' },
+  { id: 7, name: 'wo' }
+];
+const columns = [
+  { field: 'id', label: 'ID' },
+  { field: 'name', label: 'Name' }
+];
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('Wildcards in bare terms', () => {
+  test('gold* matches gold, golden, goldfish', () => {
+    const t = makeTable();
+    t.setQuery('gold*');
+    expect(t.getFilteredData().map(r => r.name).sort()).toEqual(['gold', 'golden', 'goldfish']);
+  });
+
+  test('wo?d matches word and wood, but not wo', () => {
+    const t = makeTable();
+    t.setQuery('wo?d');
+    expect(t.getFilteredData().map(r => r.name).sort()).toEqual(['wood', 'word']);
+  });
+
+  test('* matches every row (matches anything)', () => {
+    const t = makeTable();
+    t.setQuery('*');
+    expect(t.getFilteredData()).toHaveLength(data.length);
+  });
+
+  test('regex metacharacters in the term are escaped', () => {
+    const escapeData = [{ id: 1, label: 'a.b.c' }, { id: 2, label: 'aXbYc' }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const t = new TableCrafter('#t', {
+      data: escapeData,
+      columns: [{ field: 'id' }, { field: 'label' }]
+    });
+    t.setQuery('a.b*');
+    expect(t.getFilteredData().map(r => r.label)).toEqual(['a.b.c']);
+  });
+});
+
+describe('Wildcards in field:eq', () => {
+  test('name:gold* scopes the wildcard to the field', () => {
+    const t = makeTable();
+    t.setQuery('name:gold*');
+    expect(t.getFilteredData().map(r => r.name).sort()).toEqual(['gold', 'golden', 'goldfish']);
+  });
+
+  test('name:wo?d scopes the single-char wildcard', () => {
+    const t = makeTable();
+    t.setQuery('name:wo?d');
+    expect(t.getFilteredData().map(r => r.name).sort()).toEqual(['wood', 'word']);
+  });
+});
+
+describe('Wildcards do not apply inside quoted phrases', () => {
+  test('"gold*" matches the literal three characters g-o-l-d-* (none in fixture)', () => {
+    const t = makeTable();
+    t.setQuery('"gold*"');
+    expect(t.getFilteredData()).toHaveLength(0);
+  });
+});
+
+describe('Wildcards do not apply to comparison ops or strict eq', () => {
+  test('field:=gold* requires a literal value containing the asterisk', () => {
+    const literalData = [{ id: 1, code: 'gold*' }, { id: 2, code: 'golden' }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const t = new TableCrafter('#t', {
+      data: literalData,
+      columns: [{ field: 'id' }, { field: 'code' }]
+    });
+    t.setQuery('code:=gold*');
+    expect(t.getFilteredData().map(r => r.code)).toEqual(['gold*']);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #89 (comparison operators). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #89 merges.

- `*` matches zero-or-more characters; `?` matches a single character.
- Anchored: `gold*` matches `gold` / `golden` / `goldfish` but not `scaffold-thing`. Use `*gold*` for substring semantics.
- All other regex metacharacters are escaped, so `a.b*` matches `a.b.c` but not `aXbYc`.
- Wildcards are NOT applied inside quoted phrases or for `field:=` (`eq_strict`) / numeric ops (`gt` / `lt` / `gte` / `lte`) — those keep literal semantics so consumers can still search for a value containing a literal asterisk.

## Out of scope (still tracked in #59)
- Regex literals (`field:/regex/i`)
- Suggestions dropdown, builder modal, presets API
- Server-side query delegation when an API is configured

## Tests
New file `test/search-wildcards.test.js` — 8 cases:
- `gold*` matches `gold` / `golden` / `goldfish`.
- `wo?d` matches `word` / `wood`, not `wo`.
- `*` matches every row.
- Regex metachars in the term are escaped.
- `name:gold*` scopes to the named field.
- `name:wo?d` honours single-char wildcard.
- `\"gold*\"` (quoted phrase) is literal — zero matches in fixture.
- `code:=gold*` (strict eq) requires a literal `*` in the cell.

Combined: 44/44 search tests green (14 parser + 11 evaluator + 11 comparisons + 8 wildcards). Full suite: 105/106 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59