### PR TITLE
feat(search): regex literals (field:/pattern/[flags])

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2790,6 +2790,25 @@ class TableCrafter {
         const cell = row[node.field];
         if (cell === undefined || cell === null) return false;
         const op = node.op || 'eq';
+        if (op === 'regex') {
+          const key = `${node.value}|${node.flags || ''}`;
+          if (!this._regexCache) this._regexCache = new Map();
+          if (!this._badRegexWarned) this._badRegexWarned = new Set();
+          let re = this._regexCache.get(key);
+          if (!re) {
+            try {
+              re = new RegExp(node.value, node.flags || '');
+              this._regexCache.set(key, re);
+            } catch (e) {
+              if (!this._badRegexWarned.has(key)) {
+                this._badRegexWarned.add(key);
+                console.warn(`TableCrafter search: invalid regex /${node.value}/${node.flags || ''}`);
+              }
+              return false;
+            }
+          }
+          return re.test(String(cell));
+        }
         if (op === 'eq_strict') {
           return String(cell) === String(node.value);
         }
@@ -2864,10 +2883,9 @@ class TableCrafter {
       return { node: { type: 'phrase', value: tok.value }, next: i + 1 };
     }
     if (tok.type === 'field') {
-      return {
-        node: { type: 'field', field: tok.field, op: tok.op || 'eq', value: tok.value },
-        next: i + 1
-      };
+      const node = { type: 'field', field: tok.field, op: tok.op || 'eq', value: tok.value };
+      if (tok.op === 'regex') node.flags = tok.flags || '';
+      return { node, next: i + 1 };
     }
     return { node: { type: 'term', value: tok.value }, next: i + 1 };
   }
@@ -2911,6 +2929,28 @@ class TableCrafter {
 
       if (i < s.length && s[i] === ':') {
         i++; // consume colon
+
+        // Regex literal: /pattern/flags
+        if (s[i] === '/') {
+          const patternStart = i + 1;
+          let p = patternStart;
+          while (p < s.length && s[p] !== '/') {
+            if (s[p] === '\\' && p + 1 < s.length) p += 2; // skip escaped char
+            else p++;
+          }
+          const pattern = s.slice(patternStart, p);
+          let flags = '';
+          if (p < s.length && s[p] === '/') {
+            p++; // consume closing slash
+            const flagsStart = p;
+            while (p < s.length && /[a-z]/i.test(s[p])) p++;
+            flags = s.slice(flagsStart, p);
+          }
+          i = p;
+          tokens.push({ type: 'field', field: word, op: 'regex', value: pattern, flags });
+          continue;
+        }
+
         let op = 'eq';
         if (s[i] === '>' && s[i + 1] === '=') { op = 'gte'; i += 2; }
         else if (s[i] === '<' && s[i + 1] === '=') { op = 'lte'; i += 2; }

--- a/test/search-regex.test.js
+++ b/test/search-regex.test.js
@@ -1,0 +1,90 @@
+/**
+ * Search grammar — regex literals (slice 5 of #59).
+ * Stacked on PR #90 (wildcards).
+ *
+ * Adds support for `field:/pattern/` and `field:/pattern/i`. Invalid regex
+ * falls back to substring with a single console.warn (per session, per
+ * pattern) so a typo doesn't blow up the table.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, sku: 'A-100' },
+  { id: 2, sku: 'A-200' },
+  { id: 3, sku: 'B-100' },
+  { id: 4, sku: 'b-200' },
+  { id: 5, sku: 'plain' }
+];
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns: [{ field: 'id' }, { field: 'sku' }]
+  });
+}
+
+describe('parseQuery: regex literals', () => {
+  test('field:/pattern/ parses with op regex (case-sensitive by default)', () => {
+    const t = makeTable();
+    expect(t.parseQuery('sku:/^A-/')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'sku', op: 'regex', value: '^A-', flags: '' }]
+    });
+  });
+
+  test('field:/pattern/i preserves the i flag', () => {
+    const t = makeTable();
+    expect(t.parseQuery('sku:/^b-/i')).toEqual({
+      type: 'and',
+      children: [{ type: 'field', field: 'sku', op: 'regex', value: '^b-', flags: 'i' }]
+    });
+  });
+});
+
+describe('evaluateQuery: regex literals', () => {
+  test('case-sensitive regex distinguishes A vs b', () => {
+    const t = makeTable();
+    t.setQuery('sku:/^A-/');
+    expect(t.getFilteredData().map(r => r.sku).sort()).toEqual(['A-100', 'A-200']);
+  });
+
+  test('i flag enables case-insensitive matching', () => {
+    const t = makeTable();
+
+    // Case-sensitive: only b-200 matches `^b-`.
+    t.setQuery('sku:/^b-/');
+    expect(t.getFilteredData().map(r => r.sku).sort()).toEqual(['b-200']);
+
+    // Case-insensitive: B-100 also matches.
+    t.setQuery('sku:/^b-/i');
+    expect(t.getFilteredData().map(r => r.sku).sort()).toEqual(['B-100', 'b-200']);
+  });
+
+  test('non-string cells are skipped (return false)', () => {
+    const t = makeTable();
+    const ast = t.parseQuery('sku:/^[A-Z]/');
+    expect(t.evaluateQuery(ast, { sku: null })).toBe(false);
+    expect(t.evaluateQuery(ast, { sku: undefined })).toBe(false);
+  });
+});
+
+describe('evaluateQuery: invalid regex falls back gracefully', () => {
+  test('invalid pattern matches nothing and warns once per session', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const t = makeTable();
+
+    t.setQuery('sku:/[unclosed/');
+    const visible = t.getFilteredData();
+    expect(visible).toEqual([]);
+
+    // Re-applying the same bad query should not warn a second time.
+    const beforeReapply = warnSpy.mock.calls.length;
+    t.setQuery('sku:/[unclosed/');
+    const afterReapply = warnSpy.mock.calls.length;
+    expect(afterReapply).toBe(beforeReapply);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #90 (wildcards). Closes the grammar surface promised in #59 AC item 1.

- Tokeniser recognises `/pattern/[flags]` immediately after `field:`. Backslash escaping is honoured so `\\/` inside the pattern reads as a literal forward slash. Trailing alpha chars are captured as flags.
- Field AST node carries a `flags` field when `op === 'regex'`.
- Evaluator compiles each `(pattern, flags)` pair once and caches the resulting `RegExp` on the table instance.
- Invalid patterns log a one-time warning per `(pattern, flags)` tuple via `console.warn` and match nothing — a typo cannot break the table.

## Out of scope (#59 follow-ups)
- Suggestions dropdown (`config.search.suggestions`)
- Query builder modal (`config.search.builder`)
- Presets API (`config.search.presets`, `savePreset` / `removePreset`)
- Server-side query delegation when an API is configured

## Tests
New file `test/search-regex.test.js` — 6 cases:
- `sku:/^A-/` parses with `op: 'regex'` and empty flags
- `sku:/^b-/i` preserves the `i` flag
- Case-sensitive regex distinguishes `A-100` from `b-200`
- `i` flag enables case-insensitive — both `B-100` and `b-200` match
- Non-string cells (null/undefined) return `false`
- Invalid pattern matches nothing and warns once per session

Combined: 50/50 search tests green (14 parser + 11 evaluator + 11 comparisons + 8 wildcards + 6 regex). Full suite: 111/112 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59