### PR TITLE
feat(plugins): wire beforeEdit / afterEdit hooks into saveEdit()

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -1211,6 +1211,11 @@ class TableCrafter {
       }
     }
 
+    // Plugin lifecycle: beforeEdit. A handler returning false cancels.
+    if (this._fireHook && this._fireHook('beforeEdit', { rowIndex, field, value: newValue }) === false) {
+      return;
+    }
+
     // Update data
     this.data[rowIndex][field] = newValue;
 
@@ -1235,6 +1240,11 @@ class TableCrafter {
         oldValue: oldValue,
         newValue: newValue
       });
+    }
+
+    // Plugin lifecycle: afterEdit. Return value is ignored.
+    if (this._fireHook) {
+      this._fireHook('afterEdit', { rowIndex, field, oldValue, newValue });
     }
 
     // Update display with formatted value

--- a/test/plugin-edit-hooks.test.js
+++ b/test/plugin-edit-hooks.test.js
@@ -1,0 +1,115 @@
+/**
+ * Plugin lifecycle hooks: beforeEdit / afterEdit (slice 3 of #38).
+ * Stacked on PR #84 (beforeRender / afterRender + _fireHook helper).
+ *
+ * Wires the cell-edit code path so plugins can observe and gate single-cell
+ * edits. beforeLoad / afterLoad / beforeSort / afterSort / destroy remain
+ * tracked for follow-up PRs.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(plugins) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name', editable: true }],
+    data: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }],
+    editable: true,
+    plugins
+  });
+}
+
+function fakeEditElement(rowIndex, field, oldValue, newValue) {
+  const el = document.createElement('input');
+  el.dataset.rowIndex = String(rowIndex);
+  el.dataset.field = field;
+  el.dataset.originalValue = oldValue;
+  el.value = newValue;
+  return el;
+}
+
+describe('Plugin hooks: beforeEdit / afterEdit', () => {
+  test('beforeEdit fires with { rowIndex, field, value } before the mutation', async () => {
+    const beforeEdit = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { beforeEdit } }]);
+
+    const el = fakeEditElement(0, 'name', 'Alice', 'AliceX');
+    document.body.appendChild(el);
+    await table.saveEdit(el);
+
+    expect(beforeEdit).toHaveBeenCalledTimes(1);
+    expect(beforeEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ rowIndex: 0, field: 'name', value: 'AliceX' }),
+      table
+    );
+  });
+
+  test('afterEdit fires with { rowIndex, field, oldValue, newValue } after a successful edit', async () => {
+    const afterEdit = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { afterEdit } }]);
+
+    const el = fakeEditElement(0, 'name', 'Alice', 'AliceY');
+    document.body.appendChild(el);
+    await table.saveEdit(el);
+
+    expect(afterEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowIndex: 0,
+        field: 'name',
+        oldValue: 'Alice',
+        newValue: 'AliceY'
+      }),
+      table
+    );
+    expect(table.getData()[0].name).toBe('AliceY');
+  });
+
+  test('beforeEdit returning false cancels — data unchanged, afterEdit not called', async () => {
+    const afterEdit = jest.fn();
+    const table = makeTable([{
+      name: 'guard',
+      hooks: {
+        beforeEdit: () => false,
+        afterEdit
+      }
+    }]);
+
+    const el = fakeEditElement(0, 'name', 'Alice', 'BLOCKED');
+    document.body.appendChild(el);
+    await table.saveEdit(el);
+
+    expect(table.getData()[0].name).toBe('Alice');
+    expect(afterEdit).not.toHaveBeenCalled();
+  });
+
+  test('multiple plugins on the same hook fire in registration order', async () => {
+    const calls = [];
+    const make = name => ({
+      name,
+      hooks: { beforeEdit: () => { calls.push(name); } }
+    });
+    const table = makeTable([make('alpha'), make('beta'), make('gamma')]);
+
+    const el = fakeEditElement(0, 'name', 'Alice', 'X');
+    document.body.appendChild(el);
+    await table.saveEdit(el);
+
+    expect(calls).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  test('afterEdit throwing is caught and does not break the edit', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const table = makeTable([{
+      name: 'noisy',
+      hooks: { afterEdit: () => { throw new Error('boom'); } }
+    }]);
+
+    const el = fakeEditElement(0, 'name', 'Alice', 'AliceZ');
+    document.body.appendChild(el);
+    await expect(table.saveEdit(el)).resolves.not.toThrow();
+    expect(table.getData()[0].name).toBe('AliceZ');
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #84 (`beforeRender` / `afterRender` + `_fireHook` helper). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #84 merges.

- `saveEdit()` fires `beforeEdit({ rowIndex, field, value })` after validation accepts the new value but before `this.data` is mutated. A handler returning `false` cancels the edit — data is untouched, the API call is skipped, `onEdit` is not invoked, and `afterEdit` does not fire.
- `saveEdit()` fires `afterEdit({ rowIndex, field, oldValue, newValue })` immediately after the existing `onEdit` callback. Errors thrown inside any handler are caught + `console.warn`-ed (semantics inherited from `_fireHook`) so a noisy plugin cannot break a successful edit.

## Out of scope (still tracked on #38)
- `beforeLoad` / `afterLoad` wiring into `loadData()`
- `beforeSort` / `afterSort` wiring into `sort()`
- `destroy` wiring into table teardown
- Plugin-to-plugin dependency resolution

## Tests
New file `test/plugin-edit-hooks.test.js` — 5 cases:
- `beforeEdit` payload shape and call timing
- `afterEdit` payload shape (oldValue + newValue) and successful mutation
- `beforeEdit: () => false` cancels — data unchanged, `afterEdit` not called
- Multiple plugins fire in registration order
- `afterEdit` throwing is caught and a warning is logged

Combined: 27/27 plugin tests green (12 registry + 10 render hooks + 5 edit hooks). Full suite: 88/89 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38