### PR TITLE
feat(plugins): wire beforeSort / afterSort hooks into sort()

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2065,12 +2065,19 @@ class TableCrafter {
    * Sort data
    */
   sort(field) {
-    if (this.sortField === field) {
-      this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
-    } else {
-      this.sortField = field;
-      this.sortOrder = 'asc';
+    const nextOrder = (this.sortField === field)
+      ? (this.sortOrder === 'asc' ? 'desc' : 'asc')
+      : 'asc';
+
+    // Plugin lifecycle: beforeSort. Cancel-on-false aborts the sort entirely
+    // — sortField / sortOrder are not mutated, data order is preserved, and
+    // afterSort does not fire.
+    if (this._fireHook && this._fireHook('beforeSort', { field, order: nextOrder }) === false) {
+      return;
     }
+
+    this.sortField = field;
+    this.sortOrder = nextOrder;
 
     this.data.sort((a, b) => {
       const aVal = a[field];
@@ -2086,6 +2093,11 @@ class TableCrafter {
     this.currentPage = 1;
     this.saveState();
     this.render();
+
+    // Plugin lifecycle: afterSort. Return value is ignored.
+    if (this._fireHook) {
+      this._fireHook('afterSort', { field: this.sortField, order: this.sortOrder });
+    }
   }
 
   /**

--- a/test/plugin-sort-hooks.test.js
+++ b/test/plugin-sort-hooks.test.js
@@ -1,0 +1,87 @@
+/**
+ * Plugin lifecycle hooks: beforeSort / afterSort (slice 4 of #38).
+ * Stacked on PR #92 (beforeEdit / afterEdit).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(plugins) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 3, name: 'C' }, { id: 1, name: 'A' }, { id: 2, name: 'B' }],
+    sortable: true,
+    plugins
+  });
+}
+
+describe('Plugin hooks: beforeSort / afterSort', () => {
+  test('beforeSort fires with { field, order } before sorting', () => {
+    const beforeSort = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { beforeSort } }]);
+
+    table.sort('id');
+
+    expect(beforeSort).toHaveBeenCalledTimes(1);
+    expect(beforeSort).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'id', order: 'asc' }),
+      table
+    );
+  });
+
+  test('afterSort fires with { field, order } after sorting', () => {
+    const afterSort = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { afterSort } }]);
+
+    table.sort('id');
+
+    expect(afterSort).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'id', order: 'asc' }),
+      table
+    );
+    expect(table.getData().map(r => r.id)).toEqual([1, 2, 3]);
+  });
+
+  test('beforeSort returning false cancels — data order unchanged, afterSort not called', () => {
+    const afterSort = jest.fn();
+    const table = makeTable([{
+      name: 'guard',
+      hooks: {
+        beforeSort: () => false,
+        afterSort
+      }
+    }]);
+
+    const before = table.getData().map(r => r.id);
+    table.sort('id');
+    expect(table.getData().map(r => r.id)).toEqual(before);
+    expect(afterSort).not.toHaveBeenCalled();
+  });
+
+  test('beforeSort sees the toggle order on the second sort of the same field', () => {
+    const beforeSort = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { beforeSort } }]);
+
+    table.sort('id');
+    table.sort('id');
+
+    expect(beforeSort).toHaveBeenLastCalledWith(
+      expect.objectContaining({ field: 'id', order: 'desc' }),
+      table
+    );
+  });
+
+  test('afterSort throwing is caught and does not break the sort', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const table = makeTable([{
+      name: 'noisy',
+      hooks: { afterSort: () => { throw new Error('boom'); } }
+    }]);
+
+    expect(() => table.sort('id')).not.toThrow();
+    expect(table.getData().map(r => r.id)).toEqual([1, 2, 3]);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #92 (`beforeEdit` / `afterEdit`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #92 merges.

- `sort()` now computes the next-order *before* mutating `sortField` / `sortOrder` and fires `beforeSort({ field, order })` with the prospective order.
- Cancel-on-`false` leaves `sortField` / `sortOrder` / data ordering all untouched and skips `afterSort`, so the toggle state remains consistent with what plugins observed.
- `afterSort({ field, order })` fires after the data has been sorted, the page reset, and the table re-rendered. Errors thrown inside any handler are caught + `console.warn`-ed via `_fireHook`.

## Out of scope (still tracked on #38)
- `beforeLoad` / `afterLoad` wiring into `loadData()`
- `destroy` wiring into table teardown
- Plugin-to-plugin dependency resolution

## Tests
New file `test/plugin-sort-hooks.test.js` — 5 cases:
- `beforeSort` payload shape and call timing
- `afterSort` payload shape after a successful sort
- `beforeSort: () => false` cancels — data ordering unchanged, `afterSort` not called
- Toggle: second `sort` of the same field flips to `desc` and `beforeSort` sees that
- `afterSort` throwing is caught and a warning is logged

Combined: 32/32 plugin tests green (12 registry + 10 render + 5 edit + 5 sort). Full suite: 93/94 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38