### PR TITLE
feat(plugins): wire beforeLoad / afterLoad hooks into loadData()

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -340,6 +340,12 @@ class TableCrafter {
    * Load data from URL
    */
   async loadData() {
+    // Plugin lifecycle: beforeLoad. Cancel-on-false aborts before any fetch
+    // is issued and before the loading skeleton is shown.
+    if (this._fireHook && this._fireHook('beforeLoad', { source: this.dataUrl }) === false) {
+      return this.data;
+    }
+
     this.isLoading = true;
     this.renderLoading();
 
@@ -367,6 +373,7 @@ class TableCrafter {
            this.detectFilterTypes();
            this.container.dataset.ssr = "false";
            this.render();
+           if (this._fireHook) this._fireHook('afterLoad', { data: this.data });
          } catch (e) {
            console.error('TableCrafter: Hydration failed', e);
            // Silent fail for hydration is okay, user sees SSR content
@@ -384,9 +391,10 @@ class TableCrafter {
       }
       const data = await response.json();
       this.data = this.processData(data); // Using processData for consistency
-      
+
       this.autoDiscoverColumns();
       this.render();
+      if (this._fireHook) this._fireHook('afterLoad', { data: this.data });
     } catch (error) {
       console.error('TableCrafter: Load failed', error);
       this.renderError('Unable to load data. The source may be unavailable.');

--- a/test/plugin-load-hooks.test.js
+++ b/test/plugin-load-hooks.test.js
@@ -1,0 +1,89 @@
+/**
+ * Plugin lifecycle hooks: beforeLoad / afterLoad (slice 5 of #38).
+ * Stacked on PR #93 (beforeSort / afterSort).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(plugins) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: 'https://api.example.com/data',
+    plugins
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+describe('Plugin hooks: beforeLoad / afterLoad', () => {
+  test('beforeLoad fires with { source } before the fetch', async () => {
+    const beforeLoad = jest.fn();
+    const order = [];
+    fetch.mockImplementation(() => {
+      order.push('fetch');
+      return Promise.resolve({ ok: true, json: async () => [{ id: 1, name: 'A' }] });
+    });
+
+    const table = makeTable([{
+      name: 'p',
+      hooks: { beforeLoad: payload => { beforeLoad(payload); order.push('beforeLoad'); } }
+    }]);
+    await table.loadData();
+
+    expect(order[0]).toBe('beforeLoad');
+    expect(beforeLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'https://api.example.com/data' })
+    );
+  });
+
+  test('afterLoad fires with { data } after the data has been processed', async () => {
+    const payload = [{ id: 1, name: 'X' }, { id: 2, name: 'Y' }];
+    fetch.mockResolvedValue({ ok: true, json: async () => payload });
+
+    const afterLoad = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { afterLoad } }]);
+    await table.loadData();
+
+    expect(afterLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.any(Array) }),
+      table
+    );
+    expect(afterLoad.mock.calls[0][0].data).toEqual(payload);
+    expect(table.getData()).toEqual(payload);
+  });
+
+  test('beforeLoad returning false cancels — fetch is not called, afterLoad not fired', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => [] });
+    const afterLoad = jest.fn();
+
+    const table = makeTable([{
+      name: 'guard',
+      hooks: {
+        beforeLoad: () => false,
+        afterLoad
+      }
+    }]);
+    await table.loadData();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(afterLoad).not.toHaveBeenCalled();
+  });
+
+  test('afterLoad throwing is caught and does not break the load', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => [{ id: 1 }] });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const table = makeTable([{
+      name: 'noisy',
+      hooks: { afterLoad: () => { throw new Error('boom'); } }
+    }]);
+    await expect(table.loadData()).resolves.not.toThrow();
+    expect(table.getData()).toEqual([{ id: 1 }]);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #93 (`beforeSort` / `afterSort`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #93 merges.

- `loadData()` fires `beforeLoad({ source: this.dataUrl })` before any `isLoading` state change or skeleton render. Cancel-on-`false` returns the current data without issuing a fetch and without showing the loading skeleton — useful for plugins that gate background reloads.
- `afterLoad({ data })` fires in both completion branches (SSR-hydration fetch success and standard client-side load success), after the data has been processed and the table re-rendered. Errors thrown inside any handler are caught + `console.warn`-ed via `_fireHook`.

`destroy` hook wiring is the only remaining lifecycle item from the AC posted on #38.

## Tests
New file `test/plugin-load-hooks.test.js` — 4 cases:
- `beforeLoad` fires with `{ source }` *before* the fetch
- `afterLoad` fires with `{ data }` after data is processed
- `beforeLoad: () => false` cancels — `fetch` not called, `afterLoad` not fired
- `afterLoad` throwing is caught and a warning is logged

Combined: 36/36 plugin tests green (12 registry + 10 render + 5 edit + 5 sort + 4 load). Full suite: 97/98 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38