### PR TITLE
feat(plugins): wire destroy hook into table teardown

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3590,6 +3590,13 @@ class TableCrafter {
    * Destroy the table instance
    */
   destroy() {
+    // Plugin lifecycle: destroy. Fired before any teardown so handlers can
+    // observe final state. Errors are isolated by _fireHook so a noisy plugin
+    // cannot stop the rest of the teardown from running.
+    if (this._fireHook) {
+      this._fireHook('destroy', { table: this });
+    }
+
     // Save final state
     this.saveState();
 

--- a/test/plugin-destroy-hook.test.js
+++ b/test/plugin-destroy-hook.test.js
@@ -1,0 +1,55 @@
+/**
+ * Plugin lifecycle hooks: destroy (slice 6 of #38, completes the lifecycle).
+ * Stacked on PR #94 (beforeLoad / afterLoad).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(plugins) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }],
+    data: [{ id: 1 }, { id: 2 }],
+    plugins
+  });
+}
+
+describe('Plugin hooks: destroy', () => {
+  test('destroy hook fires once when table.destroy() runs', () => {
+    const destroy = jest.fn();
+    const table = makeTable([{ name: 'p', hooks: { destroy } }]);
+
+    table.destroy();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledWith(expect.any(Object), table);
+  });
+
+  test('destroy fires for every registered plugin in registration order', () => {
+    const calls = [];
+    const make = name => ({ name, hooks: { destroy: () => calls.push(name) } });
+    const table = makeTable([make('alpha'), make('beta'), make('gamma')]);
+
+    table.destroy();
+
+    expect(calls).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  test('plugin throwing in destroy does not prevent later hooks or teardown', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const lateDestroy = jest.fn();
+
+    const table = makeTable([
+      { name: 'noisy', hooks: { destroy: () => { throw new Error('boom'); } } },
+      { name: 'late',  hooks: { destroy: lateDestroy } }
+    ]);
+
+    expect(() => table.destroy()).not.toThrow();
+    expect(lateDestroy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    // Container teardown still happened.
+    expect(document.getElementById('t').innerHTML).toBe('');
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #94 (`beforeLoad` / `afterLoad`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #94 merges.

This closes the lifecycle-hooks surface posted on #38: every documented hook (`beforeRender` / `afterRender` / `beforeLoad` / `afterLoad` / `beforeEdit` / `afterEdit` / `beforeSort` / `afterSort` / `destroy`) is now wired into its respective code path.

- `destroy()` fires the `destroy` hook before any teardown so handlers can observe final state.
- Errors are isolated by `_fireHook` so a noisy plugin cannot stop the rest of the teardown (state save, listener removal, container clear, dropdown cleanup) from running.

## Out of scope (still open in #38)
- Plugin-to-plugin dependency resolution / topological install order
- Sandboxing / cross-origin plugin loading
- A built-in plugin marketplace / registry

## Tests
New file `test/plugin-destroy-hook.test.js` — 3 cases:
- `destroy` hook fires once when `table.destroy()` runs
- Multiple plugins fire in registration order
- A throwing plugin does not prevent later hooks or the actual teardown — container is still cleared

Combined: 39/39 plugin tests green (12 registry + 10 render + 5 edit + 5 sort + 4 load + 3 destroy). Full suite: 100/101 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #38