### PR TITLE
feat(i18n): formatNumber / formatDate helpers (Intl wrappers)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2740,8 +2740,27 @@ class TableCrafter {
       template = key;
     }
 
+    // Pluralisation: if the catalogue entry is a {one, other, few, ...} object
+    // and vars.count is set, pick the matching form via Intl.PluralRules.
+    if (template && typeof template === 'object' && vars && typeof vars.count === 'number') {
+      const locale = this._resolveLocale();
+      let form = 'other';
+      try {
+        form = new Intl.PluralRules(locale).select(vars.count);
+      } catch (e) {
+        // Locale unsupported by Intl.PluralRules — keep 'other'.
+      }
+      if (Object.prototype.hasOwnProperty.call(template, form)) {
+        template = template[form];
+      } else if (Object.prototype.hasOwnProperty.call(template, 'other')) {
+        template = template.other;
+      } else {
+        template = key; // No usable plural form — fall back to the key.
+      }
+    }
+
     if (typeof template !== 'string' || !vars) {
-      return template;
+      return typeof template === 'string' ? template : key;
     }
     return template.replace(/\{(\w+)\}/g, (m, name) => {
       return Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : m;
@@ -2755,6 +2774,31 @@ class TableCrafter {
       return document.documentElement.lang;
     }
     return 'en';
+  }
+
+  /**
+   * Switch the active locale and re-render. No-op (no render) when the locale
+   * is already current — avoids needless DOM rebuilds.
+   */
+  setLocale(locale) {
+    if (!this.config) this.config = {};
+    if (!this.config.i18n) this.config.i18n = { fallbackLocale: 'en', messages: {} };
+    if (this.config.i18n.locale === locale) return;
+    this.config.i18n.locale = locale;
+    this.render();
+  }
+
+  /**
+   * Merge translations into the catalogue at runtime. Existing keys for the
+   * given locale are overwritten by the supplied messages; new locales are
+   * created on demand.
+   */
+  addMessages(locale, messages) {
+    if (!this.config) this.config = {};
+    if (!this.config.i18n) this.config.i18n = { fallbackLocale: 'en', messages: {} };
+    if (!this.config.i18n.messages) this.config.i18n.messages = {};
+    const bucket = this.config.i18n.messages[locale] || {};
+    this.config.i18n.messages[locale] = Object.assign(bucket, messages || {});
   }
 
   /**

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -107,6 +107,14 @@ class TableCrafter {
         headers: {},
         authentication: null
       },
+      // i18n configuration (foundation only — pluralisation, RTL,
+      // formatNumber/Date are tracked in follow-ups for #40)
+      i18n: {
+        locale: null,            // null = resolve from document at construction time
+        fallbackLocale: 'en',
+        messages: {},
+        formats: {}
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -2705,6 +2713,49 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Translate a message key against the configured i18n catalogue.
+   * Lookup order: active locale → fallback locale → key itself (with one warn).
+   * Variable substitution: {name} placeholders read from `vars`. Missing vars
+   * leave the placeholder intact so the bug is visible rather than silently empty.
+   */
+  t(key, vars) {
+    const i18n = (this.config && this.config.i18n) || {};
+    const messages = i18n.messages || {};
+    const locale = this._resolveLocale();
+    const fallback = i18n.fallbackLocale || 'en';
+
+    let template;
+    if (messages[locale] && Object.prototype.hasOwnProperty.call(messages[locale], key)) {
+      template = messages[locale][key];
+    } else if (messages[fallback] && Object.prototype.hasOwnProperty.call(messages[fallback], key)) {
+      template = messages[fallback][key];
+    } else {
+      if (!this._missingI18nKeys) this._missingI18nKeys = new Set();
+      if (!this._missingI18nKeys.has(key)) {
+        this._missingI18nKeys.add(key);
+        console.warn(`TableCrafter i18n: missing translation for "${key}"`);
+      }
+      template = key;
+    }
+
+    if (typeof template !== 'string' || !vars) {
+      return template;
+    }
+    return template.replace(/\{(\w+)\}/g, (m, name) => {
+      return Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : m;
+    });
+  }
+
+  _resolveLocale() {
+    const i18n = (this.config && this.config.i18n) || {};
+    if (i18n.locale) return i18n.locale;
+    if (typeof document !== 'undefined' && document.documentElement && document.documentElement.lang) {
+      return document.documentElement.lang;
+    }
+    return 'en';
+  }
 
   /**
    * Set current user context

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2789,6 +2789,47 @@ class TableCrafter {
   }
 
   /**
+   * Format a number with Intl.NumberFormat using the active locale.
+   * - null / undefined → ''
+   * - non-numeric input → returned unchanged so callers can pass through
+   *   already-formatted strings without an explicit type guard.
+   * Per-call options merge over `config.i18n.formats.number` defaults.
+   */
+  formatNumber(value, options) {
+    if (value === null || value === undefined) return '';
+    const num = typeof value === 'number' ? value : Number(value);
+    if (Number.isNaN(num)) return String(value);
+
+    const i18n = (this.config && this.config.i18n) || {};
+    const defaults = (i18n.formats && i18n.formats.number) || {};
+    const merged = Object.assign({}, defaults, options || {});
+    try {
+      return new Intl.NumberFormat(this._resolveLocale(), merged).format(num);
+    } catch (e) {
+      return String(num);
+    }
+  }
+
+  /**
+   * Format a Date / ISO string / epoch ms with Intl.DateTimeFormat using the
+   * active locale. Invalid / null / undefined input returns ''.
+   */
+  formatDate(value, options) {
+    if (value === null || value === undefined) return '';
+    const date = (value instanceof Date) ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+
+    const i18n = (this.config && this.config.i18n) || {};
+    const defaults = (i18n.formats && i18n.formats.date) || {};
+    const merged = Object.assign({}, defaults, options || {});
+    try {
+      return new Intl.DateTimeFormat(this._resolveLocale(), merged).format(date);
+    } catch (e) {
+      return date.toISOString();
+    }
+  }
+
+  /**
    * Merge translations into the catalogue at runtime. Existing keys for the
    * given locale are overwritten by the supplied messages; new locales are
    * created on demand.

--- a/test/i18n-extras.test.js
+++ b/test/i18n-extras.test.js
@@ -1,0 +1,106 @@
+/**
+ * Stacked on PR #78 (i18n t() helper foundation).
+ * Adds: setLocale(), addMessages(), and {one, other} plural forms.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(i18n) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }], i18n });
+}
+
+describe('i18n: setLocale()', () => {
+  test('switches active locale and re-renders', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: { hello: 'Hello' },
+        es: { hello: 'Hola' }
+      }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+
+    expect(table.t('hello')).toBe('Hello');
+    table.setLocale('es');
+    expect(table.t('hello')).toBe('Hola');
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  test('setLocale to the same locale is a no-op (no extra render)', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { hello: 'Hello' } }
+    });
+    const renderSpy = jest.spyOn(table, 'render');
+    table.setLocale('en');
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('i18n: addMessages()', () => {
+  test('merges new keys into the active locale catalogue', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { hello: 'Hello' } }
+    });
+    table.addMessages('en', { goodbye: 'Goodbye' });
+    expect(table.t('hello')).toBe('Hello');
+    expect(table.t('goodbye')).toBe('Goodbye');
+  });
+
+  test('overrides existing keys when re-added', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { greet: 'Hi' } }
+    });
+    table.addMessages('en', { greet: 'Hello there' });
+    expect(table.t('greet')).toBe('Hello there');
+  });
+
+  test('creates a new locale bucket if it did not exist', () => {
+    const table = makeTable({ locale: 'en', messages: { en: {} } });
+    table.addMessages('fr', { hello: 'Bonjour' });
+    table.setLocale('fr');
+    expect(table.t('hello')).toBe('Bonjour');
+  });
+});
+
+describe('i18n: pluralisation', () => {
+  test('selects the {one, other} form based on vars.count', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: {
+          'rows.selected': {
+            one: '1 row selected',
+            other: '{count} rows selected'
+          }
+        }
+      }
+    });
+    expect(table.t('rows.selected', { count: 1 })).toBe('1 row selected');
+    expect(table.t('rows.selected', { count: 5 })).toBe('5 rows selected');
+    expect(table.t('rows.selected', { count: 0 })).toBe('0 rows selected');
+  });
+
+  test('falls back to "other" when "one" is missing', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: {
+        en: { items: { other: '{count} items' } }
+      }
+    });
+    expect(table.t('items', { count: 1 })).toBe('1 items');
+    expect(table.t('items', { count: 3 })).toBe('3 items');
+  });
+
+  test('returns the object stringified key when no plural forms match', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { weird: { few: 'few' } } }
+    });
+    // No 'one' or 'other' — fall back to the raw key for visibility.
+    expect(table.t('weird', { count: 1 })).toBe('weird');
+  });
+});

--- a/test/i18n-formatters.test.js
+++ b/test/i18n-formatters.test.js
@@ -1,0 +1,79 @@
+/**
+ * i18n formatNumber / formatDate helpers (slice of #40).
+ * Stacked on PR #82 (setLocale / addMessages / pluralisation).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(i18n) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { columns: [{ field: 'id' }], i18n });
+}
+
+describe('formatNumber', () => {
+  test('uses the active locale', () => {
+    const t = makeTable({ locale: 'de-DE' });
+    // German uses ',' as decimal separator and '.' as thousands separator.
+    expect(t.formatNumber(1234.5)).toBe('1.234,5');
+  });
+
+  test('honours per-call options (currency)', () => {
+    const t = makeTable({ locale: 'de-DE' });
+    const out = t.formatNumber(1234.5, { style: 'currency', currency: 'EUR' });
+    // Don't assert the exact non-breaking-space placement, just substance.
+    expect(out).toMatch(/1\.234,50/);
+    expect(out).toContain('€');
+  });
+
+  test('falls back to the configured i18n.formats.number defaults', () => {
+    const t = makeTable({
+      locale: 'en-US',
+      formats: { number: { minimumFractionDigits: 2 } }
+    });
+    expect(t.formatNumber(1)).toBe('1.00');
+  });
+
+  test('per-call options override the configured defaults', () => {
+    const t = makeTable({
+      locale: 'en-US',
+      formats: { number: { minimumFractionDigits: 2 } }
+    });
+    expect(t.formatNumber(1, { minimumFractionDigits: 0 })).toBe('1');
+  });
+
+  test('returns empty string for null / undefined', () => {
+    const t = makeTable({ locale: 'en-US' });
+    expect(t.formatNumber(null)).toBe('');
+    expect(t.formatNumber(undefined)).toBe('');
+  });
+
+  test('returns the input string when value is not numeric', () => {
+    const t = makeTable({ locale: 'en-US' });
+    expect(t.formatNumber('not a number')).toBe('not a number');
+  });
+});
+
+describe('formatDate', () => {
+  test('formats a Date in the active locale', () => {
+    const t = makeTable({ locale: 'fr-FR' });
+    const out = t.formatDate(new Date('2026-01-15T12:00:00Z'), { dateStyle: 'long' });
+    // French long-style includes the month name. Don't pin the exact day
+    // because tz can shift "15" to "14" or "16" — assert structure instead.
+    expect(out).toMatch(/janvier 2026/);
+  });
+
+  test('accepts ISO strings and numeric epoch milliseconds', () => {
+    const t = makeTable({ locale: 'en-US' });
+    const fromString = t.formatDate('2026-04-28', { dateStyle: 'short', timeZone: 'UTC' });
+    const fromEpoch = t.formatDate(Date.UTC(2026, 3, 28), { dateStyle: 'short', timeZone: 'UTC' });
+    expect(fromString).toBe(fromEpoch);
+    expect(fromString).toMatch(/4\/28\/26/);
+  });
+
+  test('returns empty string for null / undefined / invalid date', () => {
+    const t = makeTable({ locale: 'en-US' });
+    expect(t.formatDate(null)).toBe('');
+    expect(t.formatDate(undefined)).toBe('');
+    expect(t.formatDate('not a date')).toBe('');
+  });
+});

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,0 +1,98 @@
+/**
+ * i18n foundation: t(key, vars?) helper, locale resolution, fallback, warn-once.
+ * Slice of issue #40 (translation function only — pluralisation, formatNumber,
+ * formatDate, RTL handling, setLocale and built-in locale packs are tracked
+ * for follow-up PRs).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(i18n) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id', label: 'ID' }],
+    i18n
+  });
+}
+
+describe('i18n: t(key, vars?) helper', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('returns the active-locale string when the key exists', () => {
+    const table = makeTable({
+      locale: 'es',
+      messages: { es: { 'toolbar.search': 'Buscar' } }
+    });
+    expect(table.t('toolbar.search')).toBe('Buscar');
+  });
+
+  test('falls through to fallbackLocale when the key is missing in active locale', () => {
+    const table = makeTable({
+      locale: 'es',
+      fallbackLocale: 'en',
+      messages: {
+        es: { 'toolbar.search': 'Buscar' },
+        en: { 'toolbar.export': 'Export' }
+      }
+    });
+    expect(table.t('toolbar.export')).toBe('Export');
+  });
+
+  test('falls back to the key itself when no locale has it, and warns once', () => {
+    const table = makeTable({ locale: 'es', messages: { es: {} } });
+
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+    expect(table.t('totally.unknown')).toBe('totally.unknown');
+
+    const missingWarns = warnSpy.mock.calls.filter(c => /totally\.unknown/.test(String(c[0])));
+    expect(missingWarns).toHaveLength(1);
+  });
+
+  test('substitutes {var} placeholders from the vars object', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { 'pagination.pageOf': 'Page {current} of {total}' } }
+    });
+    expect(table.t('pagination.pageOf', { current: 2, total: 10 })).toBe('Page 2 of 10');
+  });
+
+  test('handles repeated and missing placeholders gracefully', () => {
+    const table = makeTable({
+      locale: 'en',
+      messages: { en: { greet: 'Hi {name}, hi again {name}!' } }
+    });
+    expect(table.t('greet', { name: 'A' })).toBe('Hi A, hi again A!');
+
+    // Missing var leaves the placeholder intact (predictable, debuggable).
+    expect(table.t('greet')).toBe('Hi {name}, hi again {name}!');
+  });
+
+  test('defaults locale to document.documentElement.lang when not set, else "en"', () => {
+    document.documentElement.lang = 'fr';
+    const t1 = makeTable({
+      messages: { fr: { hello: 'Bonjour' } }
+    });
+    expect(t1.t('hello')).toBe('Bonjour');
+
+    document.documentElement.lang = '';
+    const t2 = makeTable({
+      messages: { en: { hello: 'Hello' } }
+    });
+    expect(t2.t('hello')).toBe('Hello');
+  });
+
+  test('returns key with no warning and no error when config.i18n is absent', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', { columns: [{ field: 'id' }] });
+    expect(table.t('toolbar.search')).toBe('toolbar.search');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #82 (`setLocale` / `addMessages` / pluralisation). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #82 merges.

- `formatNumber(value, options?)` wraps `Intl.NumberFormat` with the active locale. `null` / `undefined` → `''`. Non-numeric input is returned unchanged so callers can pass through already-formatted strings without an explicit type guard. Per-call `options` merge over `config.i18n.formats.number` defaults.
- `formatDate(value, options?)` wraps `Intl.DateTimeFormat` with the active locale. Accepts `Date` instances, ISO strings, and epoch ms. Invalid / `null` / `undefined` input returns `''`. Per-call `options` merge over `config.i18n.formats.date` defaults.

## Out of scope (still tracked in #40)
- Cell-renderer auto-formatting for `number` / `date` column types
- RTL handling (`dir=\"rtl\"`, `tc-rtl` class, mirrored sort indicators)
- Built-in locale packs (`src/i18n/{es,fr,de,ar,ur}.json`)
- Migrating hard-coded English strings onto `t()`

## Tests
New file `test/i18n-formatters.test.js` — 9 cases:
- `formatNumber` uses the active locale (German thousands/decimal separators)
- Per-call currency options
- Configured `formats.number` defaults applied
- Per-call options override defaults
- `null` / `undefined` → `''`
- Non-numeric input pass-through
- `formatDate` formats in active locale (French long-style)
- Accepts Date / ISO string / epoch ms equivalently
- `null` / `undefined` / invalid date → `''`

Full suite: 85/86 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #40