### PR TITLE
feat(conditional-formatting): kind: 'icon' shorthand prepends an icon span

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2838,6 +2838,17 @@ class TableCrafter {
         Object.assign(target.style, rule.style);
       }
     }
+
+    // Icon shorthand: pick the highest-priority rule with kind:'icon' + icon
+    // and prepend a single .tc-cf-icon span. Only one icon ever wins so the
+    // cell does not collect a stack of conflicting markers.
+    const iconRule = rules.find(r => r.kind === 'icon' && typeof r.icon === 'string' && r.icon);
+    if (iconRule && target.tagName === 'TD') {
+      const span = document.createElement('span');
+      span.className = 'tc-cf-icon';
+      span.textContent = iconRule.icon;
+      target.insertBefore(span, target.firstChild);
+    }
   }
 
   /**

--- a/test/conditional-formatting-icon.test.js
+++ b/test/conditional-formatting-icon.test.js
@@ -1,0 +1,83 @@
+/**
+ * Conditional formatting — kind: 'icon' shorthand (slice 3 of #51).
+ * Stacked on PR #85 (render-loop wiring for className / style / row scope).
+ *
+ * When a rule sets `kind: 'icon'` and a non-empty `icon` string, the
+ * matching cell receives a leading <span class="tc-cf-icon"> with that
+ * icon. dataBar / colorScale and aria-label parity remain queued.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, status: 'open' },
+  { id: 2, status: 'closed' },
+  { id: 3, status: 'archived' }
+];
+const columns = [{ field: 'id' }, { field: 'status' }];
+
+function makeTable(rules) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns,
+    conditionalFormatting: { enabled: true, rules }
+  });
+}
+
+describe('Conditional formatting: kind: "icon"', () => {
+  test('matching cells get a prepended .tc-cf-icon span with the configured icon', () => {
+    const table = makeTable([
+      { id: 'flag-archived', field: 'status', when: { op: 'eq', value: 'archived' }, kind: 'icon', icon: '✗' }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="status"]');
+    expect(cells[0].querySelector('.tc-cf-icon')).toBeNull();
+    expect(cells[1].querySelector('.tc-cf-icon')).toBeNull();
+    expect(cells[2].querySelector('.tc-cf-icon')).not.toBeNull();
+    expect(cells[2].querySelector('.tc-cf-icon').textContent).toBe('✗');
+  });
+
+  test('the icon is rendered before the existing cell content', () => {
+    const table = makeTable([
+      { id: 'flag-open', field: 'status', when: { op: 'eq', value: 'open' }, kind: 'icon', icon: '✓' }
+    ]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="status"]')[0];
+    expect(cell.firstElementChild).not.toBeNull();
+    expect(cell.firstElementChild.classList.contains('tc-cf-icon')).toBe(true);
+    expect(cell.textContent).toContain('✓');
+    expect(cell.textContent).toContain('open');
+  });
+
+  test('rule with kind: "icon" but no icon string is a no-op', () => {
+    const table = makeTable([
+      { id: 'no-icon', field: 'status', when: () => true, kind: 'icon' }
+    ]);
+    table.render();
+
+    expect(document.querySelector('.tc-cf-icon')).toBeNull();
+  });
+
+  test('icon may also stack with className and style on the same rule', () => {
+    const table = makeTable([
+      {
+        id: 'combo',
+        field: 'status',
+        when: { op: 'eq', value: 'open' },
+        kind: 'icon',
+        icon: '✓',
+        className: 'flag',
+        style: { color: 'green' }
+      }
+    ]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="status"]')[0];
+    expect(cell.classList.contains('flag')).toBe(true);
+    expect(cell.style.color).toBe('green');
+    expect(cell.querySelector('.tc-cf-icon').textContent).toBe('✓');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #85 (render-loop wiring for className / style / row scope). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #85 merges.

When a matching rule sets `kind: 'icon'` and a non-empty `icon` string, the cell receives a leading `<span class=\"tc-cf-icon\">` containing that icon, inserted before the existing cell content.

- Only fires on cell scope (`target.tagName === 'TD'`) — keeps the row-scope path className-only per the AC.
- Collapses to a single span even when multiple icon rules match — the highest-priority rule wins. Cells never accumulate a stack of conflicting markers.
- Composes cleanly with `className` and `style` on the same rule.

## Out of scope (still tracked in #51)
- `kind: 'dataBar'` — width % `::after` bar inside the cell
- `kind: 'colorScale'` — interpolated background colour between min/mid/max
- `aria-label` parity for visual-only cues
- 1000-row × 5-rule perf benchmark (≤ 50ms)

## Tests
New file `test/conditional-formatting-icon.test.js` — 4 cases:
- Matching cells get a `.tc-cf-icon` span; non-matching cells do not.
- The icon span is positioned before the existing cell content.
- `kind: 'icon'` with no `icon` string is a no-op.
- Icon stacks cleanly with `className` and `style` on the same rule.

Combined: 20/20 cond-format tests green (10 evaluator + 6 render + 4 icon). Full suite: 81/82 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #51