### PR TITLE
feat(conditional-formatting): kind: 'dataBar' shorthand

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -828,7 +828,7 @@ class TableCrafter {
           if (typeof this.getMatchingRules === 'function') {
             const cellRules = this.getMatchingRules(column.field, row[column.field], row)
               .filter(r => r.scope !== 'row');
-            this._applyConditionalFormatting(td, cellRules);
+            this._applyConditionalFormatting(td, cellRules, row[column.field], column.field);
           }
 
           tr.appendChild(td);
@@ -2823,7 +2823,7 @@ class TableCrafter {
    * lower; classNames are unioned. Caller controls scope by choosing which
    * rules to pass in.
    */
-  _applyConditionalFormatting(target, rules) {
+  _applyConditionalFormatting(target, rules, value, field) {
     if (!target || !Array.isArray(rules) || rules.length === 0) return;
     // Reverse so iteration runs low → high priority and last write wins.
     const ordered = rules.slice().reverse();
@@ -2849,6 +2849,49 @@ class TableCrafter {
       span.textContent = iconRule.icon;
       target.insertBefore(span, target.firstChild);
     }
+
+    // dataBar shorthand: pick the highest-priority rule with kind:'dataBar'
+    // and append a single .tc-cf-databar span whose width % is the value's
+    // position in [min, max]. Out-of-range values clamp to 0%/100%; zero
+    // range and non-numeric values skip the bar entirely.
+    const barRule = rules.find(r => r.kind === 'dataBar');
+    if (barRule && target.tagName === 'TD') {
+      const num = (typeof value === 'number') ? value : Number(value);
+      if (!Number.isNaN(num)) {
+        const range = this._dataBarRange(barRule, field);
+        const span = document.createElement('span');
+        span.className = 'tc-cf-databar';
+        span.style.width = `${this._dataBarPercent(num, range.min, range.max)}%`;
+        target.appendChild(span);
+      }
+    }
+  }
+
+  _dataBarRange(rule, field) {
+    if (typeof rule.min === 'number' && typeof rule.max === 'number') {
+      return { min: rule.min, max: rule.max };
+    }
+    let min = Infinity;
+    let max = -Infinity;
+    for (const row of this.data) {
+      const v = Number(row[field]);
+      if (!Number.isNaN(v)) {
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+    }
+    if (min === Infinity || max === -Infinity) return { min: 0, max: 0 };
+    return {
+      min: typeof rule.min === 'number' ? rule.min : min,
+      max: typeof rule.max === 'number' ? rule.max : max
+    };
+  }
+
+  _dataBarPercent(value, min, max) {
+    if (max <= min) return 0;
+    if (value <= min) return 0;
+    if (value >= max) return 100;
+    return Math.round(((value - min) / (max - min)) * 100);
   }
 
   /**

--- a/test/conditional-formatting-databar.test.js
+++ b/test/conditional-formatting-databar.test.js
@@ -1,0 +1,115 @@
+/**
+ * Conditional formatting — kind: 'dataBar' shorthand (slice 4 of #51).
+ * Stacked on PR #98 (kind: 'icon').
+ *
+ * Renders a horizontal bar inside the cell as a child <span class="tc-cf-databar">
+ * whose inline-style width is (value - min) / (max - min) * 100%.
+ * Min/max come from the rule when explicit, otherwise are auto-computed
+ * from this.data values for that field.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, score: 0   },
+  { id: 2, score: 25  },
+  { id: 3, score: 50  },
+  { id: 4, score: 75  },
+  { id: 5, score: 100 }
+];
+const columns = [{ field: 'id' }, { field: 'score' }];
+
+function makeTable(rules) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns,
+    conditionalFormatting: { enabled: true, rules }
+  });
+}
+
+function widthOf(cell) {
+  const bar = cell.querySelector('.tc-cf-databar');
+  if (!bar) return null;
+  return bar.style.width;
+}
+
+describe('Conditional formatting: kind: "dataBar"', () => {
+  test('explicit min/max produces width = (value - min) / (max - min) * 100%', () => {
+    const table = makeTable([
+      { id: 'bar', field: 'score', when: () => true, kind: 'dataBar', min: 0, max: 100 }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(widthOf(cells[0])).toBe('0%');
+    expect(widthOf(cells[1])).toBe('25%');
+    expect(widthOf(cells[2])).toBe('50%');
+    expect(widthOf(cells[3])).toBe('75%');
+    expect(widthOf(cells[4])).toBe('100%');
+  });
+
+  test('auto-computes min/max from this.data when not provided', () => {
+    const autoData = [{ score: 10 }, { score: 30 }, { score: 50 }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: autoData,
+      columns: [{ field: 'score' }],
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{ id: 'bar', field: 'score', when: () => true, kind: 'dataBar' }]
+      }
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(widthOf(cells[0])).toBe('0%');   // value 10 = min
+    expect(widthOf(cells[1])).toBe('50%');  // value 30 = midpoint
+    expect(widthOf(cells[2])).toBe('100%'); // value 50 = max
+  });
+
+  test('clamps out-of-range values to [0%, 100%]', () => {
+    const table = makeTable([
+      { id: 'bar', field: 'score', when: () => true, kind: 'dataBar', min: 20, max: 80 }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(widthOf(cells[0])).toBe('0%');   // value 0 < min
+    expect(widthOf(cells[4])).toBe('100%'); // value 100 > max
+  });
+
+  test('skips dataBar entirely when value is non-numeric', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: [{ score: 'n/a' }, { score: 50 }],
+      columns: [{ field: 'score' }],
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{ id: 'bar', field: 'score', when: () => true, kind: 'dataBar', min: 0, max: 100 }]
+      }
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(cells[0].querySelector('.tc-cf-databar')).toBeNull();
+    expect(widthOf(cells[1])).toBe('50%');
+  });
+
+  test('zero range (min === max) renders 0% rather than NaN', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: [{ score: 5 }, { score: 5 }],
+      columns: [{ field: 'score' }],
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{ id: 'bar', field: 'score', when: () => true, kind: 'dataBar', min: 5, max: 5 }]
+      }
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(widthOf(cells[0])).toBe('0%');
+    expect(widthOf(cells[1])).toBe('0%');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #98 (`kind: 'icon'`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #98 merges.

When a matching rule sets `kind: 'dataBar'`, the cell appends a single `<span class=\"tc-cf-databar\">` child with an inline-style `width` of `((value - min) / (max - min)) * 100%`.

- Explicit `rule.min` / `rule.max` take precedence; otherwise the range is auto-computed from the numeric values in `this.data` for that field. Each end is resolved independently so a rule can fix one end and let the other auto-resolve.
- Out-of-range values clamp to `0%` / `100%`; zero range (`min === max`) collapses to `0%` rather than `NaN`.
- Non-numeric values skip the bar entirely so the cell stays plain text instead of acquiring an invisible 0%-width sliver.

The internal `_applyConditionalFormatting` signature now takes `(target, rules, value, field)`. dataBars are cell-only so the extra args are inert on the row-scope path.

## Out of scope (still tracked in #51)
- `kind: 'colorScale'` — interpolated background colour between min/mid/max
- `aria-label` parity for visual-only cues
- 1000-row × 5-rule perf benchmark (≤ 50ms)

## Tests
New file `test/conditional-formatting-databar.test.js` — 5 cases:
- Explicit min/max produces the expected width % at each fixture point
- Auto-computes min/max from `this.data` when not provided
- Clamps out-of-range values to `[0%, 100%]`
- Non-numeric values skip the bar
- Zero range (min === max) renders `0%` rather than `NaN`

Combined: 25/25 cond-format tests green (10 evaluator + 6 render + 4 icon + 5 dataBar). Full suite: 86/87 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #51