### PR TITLE
feat(conditional-formatting): kind: 'colorScale' shorthand

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2850,6 +2850,18 @@ class TableCrafter {
       target.insertBefore(span, target.firstChild);
     }
 
+    // colorScale shorthand: interpolate backgroundColor between min/[mid]/max
+    // colours based on the numeric value's position. Non-numeric values skip.
+    const scaleRule = rules.find(r => r.kind === 'colorScale');
+    if (scaleRule && target.tagName === 'TD') {
+      const num = (typeof value === 'number') ? value : Number(value);
+      if (!Number.isNaN(num)) {
+        const range = this._dataBarRange(scaleRule, field);
+        const colour = this._colorScaleAt(num, range.min, range.max, scaleRule);
+        if (colour) target.style.backgroundColor = colour;
+      }
+    }
+
     // dataBar shorthand: pick the highest-priority rule with kind:'dataBar'
     // and append a single .tc-cf-databar span whose width % is the value's
     // position in [min, max]. Out-of-range values clamp to 0%/100%; zero
@@ -2885,6 +2897,54 @@ class TableCrafter {
       min: typeof rule.min === 'number' ? rule.min : min,
       max: typeof rule.max === 'number' ? rule.max : max
     };
+  }
+
+  _colorScaleAt(value, min, max, rule) {
+    const minColor = this._parseHexColor(rule.minColor);
+    const maxColor = this._parseHexColor(rule.maxColor);
+    if (!minColor || !maxColor) return null;
+
+    if (max <= min || value <= min) return this._formatRgb(minColor);
+    if (value >= max) return this._formatRgb(maxColor);
+
+    const midColor = rule.midColor ? this._parseHexColor(rule.midColor) : null;
+    const midPoint = (typeof rule.mid === 'number') ? rule.mid : (min + max) / 2;
+
+    if (midColor) {
+      if (value <= midPoint) {
+        const t = (value - min) / (midPoint - min);
+        return this._formatRgb(this._lerpColor(minColor, midColor, t));
+      }
+      const t = (value - midPoint) / (max - midPoint);
+      return this._formatRgb(this._lerpColor(midColor, maxColor, t));
+    }
+
+    const t = (value - min) / (max - min);
+    return this._formatRgb(this._lerpColor(minColor, maxColor, t));
+  }
+
+  _parseHexColor(hex) {
+    if (typeof hex !== 'string') return null;
+    let s = hex.trim().replace(/^#/, '');
+    if (s.length === 3) s = s.split('').map(c => c + c).join('');
+    if (s.length !== 6 || !/^[0-9a-f]{6}$/i.test(s)) return null;
+    return {
+      r: parseInt(s.slice(0, 2), 16),
+      g: parseInt(s.slice(2, 4), 16),
+      b: parseInt(s.slice(4, 6), 16)
+    };
+  }
+
+  _lerpColor(a, b, t) {
+    return {
+      r: Math.round(a.r + (b.r - a.r) * t),
+      g: Math.round(a.g + (b.g - a.g) * t),
+      b: Math.round(a.b + (b.b - a.b) * t)
+    };
+  }
+
+  _formatRgb({ r, g, b }) {
+    return `rgb(${r}, ${g}, ${b})`;
   }
 
   _dataBarPercent(value, min, max) {

--- a/test/conditional-formatting-colorscale.test.js
+++ b/test/conditional-formatting-colorscale.test.js
@@ -1,0 +1,115 @@
+/**
+ * Conditional formatting — kind: 'colorScale' shorthand (slice 5 of #51).
+ * Stacked on PR #99 (kind: 'dataBar').
+ *
+ * Interpolates the cell's backgroundColor between minColor / [midColor] /
+ * maxColor based on the numeric value's position in [min, max]. Two-stop
+ * (min → max) and three-stop (min → mid → max) gradients are supported.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, score: 0   },
+  { id: 2, score: 50  },
+  { id: 3, score: 100 }
+];
+const columns = [{ field: 'id' }, { field: 'score' }];
+
+function makeTable(rule) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns,
+    conditionalFormatting: { enabled: true, rules: [rule] }
+  });
+}
+
+function bgOf(cell) {
+  // jsdom serialises rgb() as the canonical form.
+  return cell.style.backgroundColor;
+}
+
+describe('Conditional formatting: kind: "colorScale"', () => {
+  test('two-stop scale: min/max colours land at the endpoints', () => {
+    const table = makeTable({
+      id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+      min: 0, max: 100,
+      minColor: '#ff0000', maxColor: '#00ff00'
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(bgOf(cells[0])).toBe('rgb(255, 0, 0)');   // min
+    expect(bgOf(cells[2])).toBe('rgb(0, 255, 0)');   // max
+  });
+
+  test('two-stop scale midpoint is the average of the two endpoint colours', () => {
+    const table = makeTable({
+      id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+      min: 0, max: 100,
+      minColor: '#ff0000', maxColor: '#00ff00'
+    });
+    table.render();
+
+    const mid = document.querySelectorAll('td[data-field="score"]')[1];
+    // value 50 = midpoint → average of red and green channels.
+    expect(bgOf(mid)).toBe('rgb(128, 128, 0)');
+  });
+
+  test('three-stop scale interpolates through midColor at the midpoint', () => {
+    const table = makeTable({
+      id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+      min: 0, max: 100, mid: 50,
+      minColor: '#ff0000', midColor: '#ffff00', maxColor: '#00ff00'
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(bgOf(cells[0])).toBe('rgb(255, 0, 0)');
+    expect(bgOf(cells[1])).toBe('rgb(255, 255, 0)'); // exactly midColor
+    expect(bgOf(cells[2])).toBe('rgb(0, 255, 0)');
+  });
+
+  test('clamps below min and above max', () => {
+    const wider = [{ score: -10 }, { score: 200 }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: wider,
+      columns: [{ field: 'score' }],
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{
+          id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+          min: 0, max: 100,
+          minColor: '#ff0000', maxColor: '#00ff00'
+        }]
+      }
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(bgOf(cells[0])).toBe('rgb(255, 0, 0)');
+    expect(bgOf(cells[1])).toBe('rgb(0, 255, 0)');
+  });
+
+  test('non-numeric value skips colorScale entirely', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      data: [{ score: 'n/a' }],
+      columns: [{ field: 'score' }],
+      conditionalFormatting: {
+        enabled: true,
+        rules: [{
+          id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+          min: 0, max: 100,
+          minColor: '#ff0000', maxColor: '#00ff00'
+        }]
+      }
+    });
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="score"]')[0];
+    expect(bgOf(cell)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #99 (`kind: 'dataBar'`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #99 merges.

When a matching rule sets `kind: 'colorScale'`, the cell's `backgroundColor` is set by interpolating between `minColor` / [`midColor`] / `maxColor` based on the numeric value's position in `[min, max]`.

- **Two-stop gradient** (minColor → maxColor) when no midColor is set.
- **Three-stop gradient** (minColor → midColor → maxColor) when midColor is provided. The pivot is `rule.mid` if numeric, otherwise `(min + max) / 2`.
- Out-of-range values clamp to `minColor` / `maxColor`; zero range collapses to `minColor` rather than `NaN`.
- Non-numeric values skip the scale entirely.
- Hex inputs (`#abc`, `#aabbcc`) are parsed; other formats are ignored (the rule degrades to a no-op rather than corrupting the cell).

## Out of scope (still tracked in #51)
- `aria-label` parity for visual-only cues — this PR sets `backgroundColor` without textual support yet
- 1000-row × 5-rule perf benchmark (≤ 50ms)
- A UI rule-builder modal

## Tests
New file `test/conditional-formatting-colorscale.test.js` — 5 cases:
- Two-stop endpoints land at `minColor` / `maxColor`
- Two-stop midpoint is the channel-wise average
- Three-stop interpolates through `midColor` exactly at the pivot
- Out-of-range values clamp
- Non-numeric value leaves `backgroundColor` empty

Combined: 30/30 cond-format tests green (10 evaluator + 6 render + 4 icon + 5 dataBar + 5 colorScale). Full suite: 91/92 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #51