### PR TITLE
feat(conditional-formatting): aria-label parity for visual-only cues

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -828,7 +828,7 @@ class TableCrafter {
           if (typeof this.getMatchingRules === 'function') {
             const cellRules = this.getMatchingRules(column.field, row[column.field], row)
               .filter(r => r.scope !== 'row');
-            this._applyConditionalFormatting(td, cellRules, row[column.field], column.field);
+            this._applyConditionalFormatting(td, cellRules, row[column.field], column.field, row);
           }
 
           tr.appendChild(td);
@@ -2823,7 +2823,7 @@ class TableCrafter {
    * lower; classNames are unioned. Caller controls scope by choosing which
    * rules to pass in.
    */
-  _applyConditionalFormatting(target, rules, value, field) {
+  _applyConditionalFormatting(target, rules, value, field, row) {
     if (!target || !Array.isArray(rules) || rules.length === 0) return;
     // Reverse so iteration runs low → high priority and last write wins.
     const ordered = rules.slice().reverse();
@@ -2859,6 +2859,7 @@ class TableCrafter {
         const range = this._dataBarRange(scaleRule, field);
         const colour = this._colorScaleAt(num, range.min, range.max, scaleRule);
         if (colour) target.style.backgroundColor = colour;
+        this._applyConditionalAriaLabel(target, scaleRule, value, field, row);
       }
     }
 
@@ -2875,7 +2876,26 @@ class TableCrafter {
         span.className = 'tc-cf-databar';
         span.style.width = `${this._dataBarPercent(num, range.min, range.max)}%`;
         target.appendChild(span);
+        this._applyConditionalAriaLabel(target, barRule, value, field, row);
       }
+    }
+  }
+
+  _applyConditionalAriaLabel(target, rule, value, field, row) {
+    if (!target || target.tagName !== 'TD') return;
+    if (target.hasAttribute('aria-label')) return; // first-write wins
+    let label;
+    if (typeof rule.ariaLabel === 'function') {
+      try {
+        label = rule.ariaLabel(value, row);
+      } catch (e) {
+        label = null;
+      }
+    } else {
+      label = `${field}: ${value}`;
+    }
+    if (typeof label === 'string' && label) {
+      target.setAttribute('aria-label', label);
     }
   }
 

--- a/test/conditional-formatting-aria.test.js
+++ b/test/conditional-formatting-aria.test.js
@@ -1,0 +1,86 @@
+/**
+ * Conditional formatting — aria-label parity for visual-only cues (slice 6 of #51).
+ * Stacked on PR #100 (kind: 'colorScale').
+ *
+ * Closes AC item 6: built-in `colorScale` and `dataBar` cells get an
+ * `aria-label="${field}: ${value}"` by default; consumer-supplied
+ * `ariaLabel(value, row)` overrides the default.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, score: 25, label: 'Low'  },
+  { id: 2, score: 75, label: 'High' }
+];
+const columns = [{ field: 'id' }, { field: 'score' }, { field: 'label' }];
+
+function makeTable(rule) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    data,
+    columns,
+    conditionalFormatting: { enabled: true, rules: [rule] }
+  });
+}
+
+describe('Conditional formatting: aria-label for visual-only cues', () => {
+  test('colorScale cells get aria-label="${field}: ${value}" by default', () => {
+    const table = makeTable({
+      id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+      min: 0, max: 100, minColor: '#ff0000', maxColor: '#00ff00'
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(cells[0].getAttribute('aria-label')).toBe('score: 25');
+    expect(cells[1].getAttribute('aria-label')).toBe('score: 75');
+  });
+
+  test('dataBar cells get aria-label="${field}: ${value}" by default', () => {
+    const table = makeTable({
+      id: 'b', field: 'score', when: () => true, kind: 'dataBar',
+      min: 0, max: 100
+    });
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="score"]')[0];
+    expect(cell.getAttribute('aria-label')).toBe('score: 25');
+  });
+
+  test('custom ariaLabel(value, row) overrides the default', () => {
+    const table = makeTable({
+      id: 'g', field: 'score', when: () => true, kind: 'colorScale',
+      min: 0, max: 100, minColor: '#ff0000', maxColor: '#00ff00',
+      ariaLabel: (value, row) => `${row.label} score (${value} of 100)`
+    });
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="score"]');
+    expect(cells[0].getAttribute('aria-label')).toBe('Low score (25 of 100)');
+    expect(cells[1].getAttribute('aria-label')).toBe('High score (75 of 100)');
+  });
+
+  test('plain className/style rules do not add aria-label by themselves', () => {
+    const table = makeTable({
+      id: 'flag', field: 'score', when: () => true, className: 'plain'
+    });
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="score"]')[0];
+    expect(cell.classList.contains('plain')).toBe(true);
+    expect(cell.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('rule with kind: "icon" does not add aria-label automatically (icon is visible text)', () => {
+    const table = makeTable({
+      id: 'i', field: 'score', when: () => true, kind: 'icon', icon: '✓'
+    });
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="score"]')[0];
+    // Icon is rendered as inline text, screen readers read it directly,
+    // so no extra aria-label is needed (consumers can opt in via ariaLabel).
+    expect(cell.getAttribute('aria-label')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #100 (`kind: 'colorScale'`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #100 merges.

Closes #51 AC item 6: built-in `colorScale` and `dataBar` shorthands set `aria-label` on the target cell so screen readers receive the value the visual cue is encoding.

- Default label is `${field}: ${value}`.
- Rule may supply `ariaLabel(value, row)` to override; throws inside the callback are caught and the label is silently skipped (no DOM pollution).
- First-write wins: if a higher-priority rule already set `aria-label`, lower-priority `colorScale` / `dataBar` rules do not overwrite it.
- className-only and style-only rules do NOT auto-label (those cues typically pair with the cell's existing text and don't need extra narration).
- `kind: 'icon'` also skips auto-labelling — the icon glyph is read directly by screen readers.

After this merges the only #51 item not in flight is the soft-cap performance benchmark (1000 rows × 5 rules ≤ 50ms), which is gated on the bench harness from #55.

## Tests
New file `test/conditional-formatting-aria.test.js` — 5 cases:
- `colorScale` cells get default `aria-label`
- `dataBar` cells get default `aria-label`
- Custom `ariaLabel(value, row)` callback wins
- Plain `className` / `style` rules do not auto-label
- `kind: 'icon'` rules do not auto-label

Combined: 35/35 cond-format tests green (10 evaluator + 6 render + 4 icon + 5 dataBar + 5 colorScale + 5 aria). Full suite: 96/97 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #51