### PR TITLE
feat(validation): add validate / getErrors / clearErrors public API

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3426,6 +3426,77 @@ class TableCrafter {
   }
 
   /**
+   * Validate the entire dataset and return an aggregated result without
+   * mutating tooltip DOM. Errors are keyed by rowIndex; each row's value is
+   * an object of { field: errors[] } for the fields that failed.
+   */
+  async validate() {
+    if (!this.config.validation || !this.config.validation.enabled) {
+      return { isValid: true, errors: {} };
+    }
+    const errors = {};
+    let isValid = true;
+    for (let rowIndex = 0; rowIndex < this.data.length; rowIndex++) {
+      const row = this.data[rowIndex];
+      const rowErrors = {};
+      let rowValid = true;
+      for (const column of this.config.columns || []) {
+        const result = this.validateField(column.field, row[column.field], row);
+        if (result && !result.isValid) {
+          rowErrors[column.field] = result.errors;
+          rowValid = false;
+        }
+      }
+      if (!rowValid) {
+        errors[rowIndex] = rowErrors;
+        isValid = false;
+      }
+    }
+    return { isValid, errors };
+  }
+
+  /**
+   * Defensive snapshot of the validationErrors map.
+   * - getErrors() → { [rowIndex]: { [field]: errors[] } } across all rows.
+   * - getErrors(rowIndex) → { [field]: errors[] } for one row (no rowIndex key).
+   * Both forms deep-clone arrays so callers can mutate without leaking back.
+   */
+  getErrors(rowIndex) {
+    const all = {};
+    for (const [key, errs] of this.validationErrors.entries()) {
+      const sep = key.indexOf('_');
+      if (sep === -1) continue;
+      const idx = Number(key.slice(0, sep));
+      const field = key.slice(sep + 1);
+      if (!all[idx]) all[idx] = {};
+      all[idx][field] = (errs || []).slice();
+    }
+    if (rowIndex === undefined) return all;
+    return all[rowIndex] || {};
+  }
+
+  /**
+   * Clear validation errors at the given scope.
+   * - clearErrors() → wipes every entry.
+   * - clearErrors(rowIndex) → wipes every field on that row.
+   * - clearErrors(rowIndex, field) → wipes only that field on that row.
+   */
+  clearErrors(rowIndex, field) {
+    if (rowIndex === undefined) {
+      this.validationErrors.clear();
+      return;
+    }
+    if (field !== undefined) {
+      this.validationErrors.delete(`${rowIndex}_${field}`);
+      return;
+    }
+    const prefix = `${rowIndex}_`;
+    for (const key of Array.from(this.validationErrors.keys())) {
+      if (key.startsWith(prefix)) this.validationErrors.delete(key);
+    }
+  }
+
+  /**
    * Clear all validation errors
    */
   clearAllValidationErrors() {

--- a/test/validation-public-api.test.js
+++ b/test/validation-public-api.test.js
@@ -1,0 +1,151 @@
+/**
+ * Public validation API: validate() / getErrors() / clearErrors() (slice of #41).
+ *
+ * Self-contained: branched off main. The table.validate() helper returns an
+ * aggregated result without mutating tooltip DOM, getErrors() exposes a
+ * defensive copy of the internal validationErrors Map, and clearErrors()
+ * narrows the clear by rowIndex / field.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseMessages = {
+  required: 'This field is required',
+  email: 'Please enter a valid email address',
+  minLength: 'Minimum length is {min} characters',
+  maxLength: 'Maximum length is {max} characters',
+  min: 'Minimum value is {min}',
+  max: 'Maximum value is {max}',
+  pattern: 'Please enter a valid format',
+  custom: 'Validation failed'
+};
+
+function makeTable(rules, data) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [
+      { field: 'name' },
+      { field: 'email' }
+    ],
+    data,
+    validation: {
+      enabled: true,
+      showErrors: true,
+      validateOnEdit: true,
+      validateOnSubmit: true,
+      rules,
+      messages: baseMessages
+    }
+  });
+}
+
+describe('validate(): full-dataset validation', () => {
+  test('returns isValid: true and an empty errors map when every row passes', async () => {
+    const t = makeTable({
+      name: { required: true },
+      email: { email: true }
+    }, [
+      { name: 'Alice', email: 'alice@example.com' },
+      { name: 'Bob',   email: 'bob@example.com' }
+    ]);
+
+    const result = await t.validate();
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual({});
+  });
+
+  test('returns aggregated errors keyed by rowIndex with field-level error arrays', async () => {
+    const t = makeTable({
+      name: { required: true },
+      email: { email: true }
+    }, [
+      { name: '',       email: 'alice@example.com' },
+      { name: 'Bob',    email: 'not-an-email'      },
+      { name: 'Carol',  email: 'carol@example.com' }
+    ]);
+
+    const result = await t.validate();
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toEqual({ name: expect.arrayContaining([expect.stringMatching(/required/i)]) });
+    expect(result.errors[1]).toEqual({ email: expect.arrayContaining([expect.stringMatching(/email/i)]) });
+    expect(result.errors[2]).toBeUndefined();
+  });
+
+  test('does not mutate tooltip DOM', async () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }]);
+    document.body.innerHTML += '<div id="probe"></div>'; // sentinel
+    await t.validate();
+    expect(document.querySelector('.tc-validation-tooltip')).toBeNull();
+  });
+
+  test('resolves a real Promise (not a sync result)', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }]);
+    const p = t.validate();
+    expect(typeof p.then).toBe('function');
+  });
+});
+
+describe('getErrors(): defensive snapshot', () => {
+  test('returns the full errors map keyed by rowIndex when called with no args', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }, { name: 'Bob' }]);
+    t.setValidationError(0, 'name', ['This field is required']);
+
+    const out = t.getErrors();
+    expect(out[0].name).toEqual(['This field is required']);
+    expect(out[1]).toBeUndefined();
+  });
+
+  test('returns just the row when called with a rowIndex', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }, { name: 'Bob' }]);
+    t.setValidationError(0, 'name', ['This field is required']);
+    t.setValidationError(1, 'name', ['Other error']);
+
+    expect(t.getErrors(0)).toEqual({ name: ['This field is required'] });
+    expect(t.getErrors(1)).toEqual({ name: ['Other error'] });
+  });
+
+  test('mutating the snapshot does not affect internal state', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }]);
+    t.setValidationError(0, 'name', ['msg']);
+
+    const snap = t.getErrors();
+    snap[0].name.push('TAMPER');
+
+    expect(t.getErrors(0).name).toEqual(['msg']);
+  });
+});
+
+describe('clearErrors(): narrowed clearing', () => {
+  test('clearErrors(rowIndex, field) clears only that field for that row', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }]);
+    t.setValidationError(0, 'name', ['msg']);
+    t.setValidationError(0, 'email', ['email msg']);
+
+    t.clearErrors(0, 'name');
+
+    expect(t.getErrors(0).name).toBeUndefined();
+    expect(t.getErrors(0).email).toEqual(['email msg']);
+  });
+
+  test('clearErrors(rowIndex) clears every field on that row', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }, { name: '' }]);
+    t.setValidationError(0, 'name', ['a']);
+    t.setValidationError(0, 'email', ['b']);
+    t.setValidationError(1, 'name', ['c']);
+
+    t.clearErrors(0);
+
+    expect(t.getErrors(0)).toEqual({});
+    expect(t.getErrors(1)).toEqual({ name: ['c'] });
+  });
+
+  test('clearErrors() clears every error map-wide', () => {
+    const t = makeTable({ name: { required: true } }, [{ name: '' }, { name: '' }]);
+    t.setValidationError(0, 'name', ['a']);
+    t.setValidationError(1, 'name', ['b']);
+
+    t.clearErrors();
+
+    expect(t.getErrors()).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
Slice of #41 AC item 5. Self-contained: branched off `main` rather than off any existing #41 slice so the rule-library expansion PRs (#77, #81, #102) and this API PR can merge in any order.

- `table.validate()` → `Promise<{ isValid, errors }>` walks the whole dataset, runs `validateField` per (row, column) pair, and returns an aggregated errors map keyed by `rowIndex` without mutating tooltip DOM. Empty / disabled validation resolves `true` with `{}`.
- `table.getErrors(rowIndex?)` returns a defensive snapshot of the internal `validationErrors` Map. Without `rowIndex`, shape is `{ [rowIndex]: { [field]: errors[] } }`; with `rowIndex`, just the inner per-field map. Arrays are cloned so caller mutation cannot leak back into internal state.
- `table.clearErrors(rowIndex?, field?)` narrows the clear: no args wipes everything, `rowIndex` alone wipes a row, both args wipe one cell. Existing `clearAllValidationErrors()` is preserved unchanged.

## Out of scope (still in #41)
- Async validation rules (`Promise<{ isValid, errors }>` per-rule) and the `tc-validating` spinner cell state
- `rowRules: Array<({ row }) => Array<{ field, message }>>` cross-field rules
- `aria-invalid` / `aria-describedby` wiring on the rendered cell
- WordPress-parity hook for `column.gfFieldId` over REST
- Aggregated `[role=\"alert\"]` summary element

## Tests
New file `test/validation-public-api.test.js` — 10 cases:
- `validate()` returns `{ isValid: true, errors: {} }` for a fully-valid dataset
- Aggregates errors keyed by `rowIndex`, with field-level error arrays
- Does not paint tooltip DOM
- Resolves a real Promise
- `getErrors()` returns the full snapshot
- `getErrors(rowIndex)` returns just one row's per-field map
- Mutating the snapshot leaves internal state intact
- `clearErrors(rowIndex, field)` is field-scoped
- `clearErrors(rowIndex)` is row-scoped
- `clearErrors()` is map-wide

Full suite: 71/72 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #41