### PR TITLE
feat(validation): cross-field rowRules in validate()

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3434,19 +3434,44 @@ class TableCrafter {
     if (!this.config.validation || !this.config.validation.enabled) {
       return { isValid: true, errors: {} };
     }
+    const rowRules = Array.isArray(this.config.validation.rowRules)
+      ? this.config.validation.rowRules
+      : [];
+
     const errors = {};
     let isValid = true;
     for (let rowIndex = 0; rowIndex < this.data.length; rowIndex++) {
       const row = this.data[rowIndex];
       const rowErrors = {};
       let rowValid = true;
+
+      // Per-field rules first.
       for (const column of this.config.columns || []) {
         const result = this.validateField(column.field, row[column.field], row);
         if (result && !result.isValid) {
-          rowErrors[column.field] = result.errors;
+          rowErrors[column.field] = (rowErrors[column.field] || []).concat(result.errors);
           rowValid = false;
         }
       }
+
+      // Cross-field row rules. Errors append to per-field rule errors so
+      // both error types are visible on the same cell when both fire.
+      for (const rule of rowRules) {
+        let produced = [];
+        try {
+          produced = rule({ row, rowIndex }) || [];
+        } catch (e) {
+          console.warn('TableCrafter validation: rowRule threw', e);
+          continue;
+        }
+        if (!Array.isArray(produced)) continue;
+        for (const entry of produced) {
+          if (!entry || !entry.field || typeof entry.message !== 'string') continue;
+          rowErrors[entry.field] = (rowErrors[entry.field] || []).concat([entry.message]);
+          rowValid = false;
+        }
+      }
+
       if (!rowValid) {
         errors[rowIndex] = rowErrors;
         isValid = false;

--- a/test/validation-row-rules.test.js
+++ b/test/validation-row-rules.test.js
@@ -1,0 +1,119 @@
+/**
+ * Cross-field validation: config.validation.rowRules (slice of #41 AC item 2).
+ * Stacked on PR #103 (validate / getErrors / clearErrors public API).
+ *
+ * rowRules is an Array<({ row }) => Array<{ field, message }>>. Each rule
+ * function is called per row during validate(); returned errors decorate
+ * the named field exactly like single-field validation errors.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const baseMessages = {
+  required: 'This field is required',
+  email: 'Please enter a valid email address',
+  minLength: 'Minimum length is {min} characters',
+  maxLength: 'Maximum length is {max} characters',
+  min: 'Minimum value is {min}',
+  max: 'Maximum value is {max}',
+  pattern: 'Please enter a valid format',
+  custom: 'Validation failed'
+};
+
+function makeTable(extra) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [
+      { field: 'start' },
+      { field: 'end' },
+      { field: 'password' },
+      { field: 'confirm' }
+    ],
+    validation: {
+      enabled: true,
+      showErrors: true,
+      validateOnEdit: true,
+      validateOnSubmit: true,
+      rules: {},
+      messages: baseMessages,
+      ...extra
+    }
+  });
+}
+
+describe('rowRules: cross-field validation', () => {
+  test('a passing rule produces no errors', async () => {
+    const t = makeTable({
+      rowRules: [({ row }) => row.start <= row.end ? [] : [{ field: 'end', message: 'end must follow start' }]
+      ]
+    });
+    t.data = [{ start: 1, end: 5 }];
+
+    const result = await t.validate();
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual({});
+  });
+
+  test('a failing rule decorates the named field', async () => {
+    const t = makeTable({
+      rowRules: [
+        ({ row }) => row.start <= row.end ? [] : [{ field: 'end', message: 'end must follow start' }]
+      ]
+    });
+    t.data = [{ start: 10, end: 5 }];
+
+    const result = await t.validate();
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0].end).toEqual(['end must follow start']);
+  });
+
+  test('multiple errors from one rule decorate multiple fields', async () => {
+    const t = makeTable({
+      rowRules: [
+        ({ row }) => row.password === row.confirm ? [] : [
+          { field: 'password', message: 'must match' },
+          { field: 'confirm',  message: 'must match' }
+        ]
+      ]
+    });
+    t.data = [{ password: 'a', confirm: 'b' }];
+
+    const result = await t.validate();
+    expect(result.errors[0].password).toEqual(['must match']);
+    expect(result.errors[0].confirm).toEqual(['must match']);
+  });
+
+  test('row-rule errors merge with single-field rule errors on the same field', async () => {
+    const t = makeTable({
+      rules: { end: { required: true } },
+      rowRules: [
+        ({ row }) => row.start <= row.end ? [] : [{ field: 'end', message: 'end must follow start' }]
+      ]
+    });
+    t.data = [{ start: 10, end: '' }];
+
+    const result = await t.validate();
+    // Field rule fires first (required), row rule appends.
+    expect(result.errors[0].end).toEqual(expect.arrayContaining([
+      expect.stringMatching(/required/i),
+      'end must follow start'
+    ]));
+  });
+
+  test('a throwing row-rule does not break validate() — error is swallowed', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const t = makeTable({
+      rowRules: [
+        () => { throw new Error('boom'); },
+        ({ row }) => row.start <= row.end ? [] : [{ field: 'end', message: 'm' }]
+      ]
+    });
+    t.data = [{ start: 10, end: 5 }];
+
+    const result = await t.validate();
+    expect(result.errors[0].end).toEqual(['m']);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #103 (`validate` / `getErrors` / `clearErrors` public API). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #103 merges.

Closes #41 AC item 2.

`config.validation.rowRules` is `Array<({ row, rowIndex }) => Array<{ field, message }>>`. `validate()` now runs each row through every `rowRule` in addition to the per-field rules; returned errors decorate the named field in the aggregated errors map.

- Multiple `rowRules` can each return errors for multiple fields.
- `rowRule` errors append to per-field rule errors on the same field so both kinds are visible together.
- A throwing `rowRule` is caught and `console.warn`-ed; subsequent rules on the same row continue to run.
- Returned items missing `field` or `message` are silently skipped so a half-populated rule cannot inject malformed entries.

## Out of scope (still in #41)
- Async per-rule validation (`Promise<{ isValid, errors }>` for `validateField`)
- `tc-validating` spinner cell state for in-flight async rules
- `aria-invalid` / `aria-describedby` wiring on the rendered cell
- Aggregated `[role=\"alert\"]` summary element
- WordPress-parity hook for `column.gfFieldId`

## Tests
New file `test/validation-row-rules.test.js` — 5 cases:
- Passing rule produces no errors
- Failing rule decorates the named field
- One rule returning multiple `{ field, message }` decorates multiple fields
- `rowRule` errors append to per-field rule errors on the same field
- A throwing `rowRule` is caught and later rules still run

Combined with the public API tests from PR #103: 15/15 validation API tests green. Full suite: 76/77 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #41