### PR TITLE
feat(context-menu): programmatic openContextMenu / closeContextMenu foundation

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -130,6 +130,10 @@ class TableCrafter {
         enabled: false,
         rules: []
       },
+      contextMenu: {
+        enabled: false,
+        items: []
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -3203,6 +3207,75 @@ class TableCrafter {
       version: p.plugin.version,
       options: p.options
     }));
+  }
+
+  openContextMenu(scope, context) {
+    const cfg = this.config && this.config.contextMenu;
+    if (!cfg || !cfg.enabled) return;
+    this.closeContextMenu();
+
+    const fullContext = Object.assign({ scope }, context || {});
+    const items = (cfg.items || []).filter(item => {
+      if (item === 'separator') return true;
+      if (!item) return false;
+      if (item.scope && item.scope !== 'all' && item.scope !== scope) return false;
+      if (typeof item.visible === 'function') {
+        try {
+          if (item.visible({ context: fullContext }) === false) return false;
+        } catch (e) {
+          return false;
+        }
+      }
+      return true;
+    });
+    if (items.length === 0) return;
+
+    const menu = document.createElement('ul');
+    menu.className = 'tc-context-menu';
+    menu.setAttribute('role', 'menu');
+
+    for (const item of items) {
+      if (item === 'separator') {
+        const sep = document.createElement('li');
+        sep.setAttribute('role', 'separator');
+        menu.appendChild(sep);
+        continue;
+      }
+      const li = document.createElement('li');
+      li.setAttribute('role', 'menuitem');
+      li.textContent = item.label || '';
+      let disabled = false;
+      if (typeof item.disabled === 'function') {
+        try {
+          disabled = item.disabled({ context: fullContext }) === true;
+        } catch (e) {
+          disabled = true;
+        }
+      }
+      if (disabled) li.setAttribute('aria-disabled', 'true');
+      li.addEventListener('click', () => {
+        if (disabled) return;
+        try {
+          if (typeof item.onClick === 'function') {
+            item.onClick({ context: fullContext });
+          }
+        } catch (e) {
+          console.warn('TableCrafter contextMenu: onClick threw', e);
+        }
+        this.closeContextMenu();
+      });
+      menu.appendChild(li);
+    }
+
+    document.body.appendChild(menu);
+    this._contextMenu = menu;
+  }
+
+  closeContextMenu() {
+    if (this._contextMenu && this._contextMenu.parentNode) {
+      this._contextMenu.parentNode.removeChild(this._contextMenu);
+    }
+    this._contextMenu = null;
   }
 
   /**

--- a/test/context-menu.test.js
+++ b/test/context-menu.test.js
@@ -1,0 +1,176 @@
+/**
+ * Context menu — programmatic foundation (slice 1 of #44).
+ *
+ * Lands the config surface, `openContextMenu(scope, context)`,
+ * `closeContextMenu()`, and the public `menuItems` resolution. The actual
+ * `contextmenu` event listener wiring, keyboard navigation, touch long-press,
+ * and viewport-flip positioning are deferred to follow-up PRs and remain
+ * tracked on #44.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }],
+    ...extra
+  });
+}
+
+afterEach(() => {
+  document.querySelectorAll('.tc-context-menu').forEach(el => el.remove());
+});
+
+describe('Context menu: disabled by default', () => {
+  test('openContextMenu does nothing when contextMenu.enabled is false (default)', () => {
+    const table = makeTable();
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+});
+
+describe('Context menu: custom items', () => {
+  test('renders <ul role="menu"> with one <li role="menuitem"> per item', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick },
+          { id: 'b', label: 'Beta',  onClick }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    const menu = document.querySelector('.tc-context-menu');
+    expect(menu).not.toBeNull();
+    expect(menu.getAttribute('role')).toBe('menu');
+
+    const items = menu.querySelectorAll('li[role="menuitem"]');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('Alpha');
+    expect(items[1].textContent).toBe('Beta');
+  });
+
+  test('clicking an item invokes onClick with { context }', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 1, row: { id: 2, name: 'B' } });
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0][0].context).toEqual(
+      expect.objectContaining({ scope: 'row', rowIndex: 1, row: { id: 2, name: 'B' } })
+    );
+  });
+
+  test('visible: false omits the item', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick: () => {} },
+          { id: 'b', label: 'Beta',  onClick: () => {}, visible: () => false }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const items = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe('Alpha');
+  });
+
+  test('disabled: true marks the item aria-disabled and skips onClick', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick, disabled: () => true }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const item = document.querySelector('.tc-context-menu li[role="menuitem"]');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+
+    item.click();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('item.scope filters which scopes show the item', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'r', label: 'Row only',    onClick: () => {}, scope: 'row' },
+          { id: 'h', label: 'Header only', onClick: () => {}, scope: 'header' },
+          { id: 'a', label: 'Anywhere',    onClick: () => {} }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    let labels = Array.from(document.querySelectorAll('.tc-context-menu li')).map(li => li.textContent);
+    expect(labels).toEqual(['Row only', 'Anywhere']);
+
+    table.closeContextMenu();
+    table.openContextMenu('header', { field: 'name' });
+    labels = Array.from(document.querySelectorAll('.tc-context-menu li')).map(li => li.textContent);
+    expect(labels).toEqual(['Header only', 'Anywhere']);
+  });
+});
+
+describe('Context menu: separator', () => {
+  test('"separator" entries render an <li role="separator"> without text', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick: () => {} },
+          'separator',
+          { id: 'b', label: 'Beta',  onClick: () => {} }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const seps = document.querySelectorAll('.tc-context-menu li[role="separator"]');
+    expect(seps).toHaveLength(1);
+    expect(seps[0].textContent.trim()).toBe('');
+  });
+});
+
+describe('Context menu: closeContextMenu()', () => {
+  test('removes the menu from the DOM', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick: () => {} }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+
+    table.closeContextMenu();
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+
+  test('closeContextMenu when no menu is open is a no-op', () => {
+    const table = makeTable({
+      contextMenu: { enabled: true, items: [{ id: 'a', label: 'Alpha', onClick: () => {} }] }
+    });
+    expect(() => table.closeContextMenu()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Slice 1 of issue #44. Lands the config surface and a programmatic menu builder so the rest of the issue (event-listener wiring, keyboard nav, touch long-press, viewport-flip positioning, focus management) can layer on top in follow-up PRs.

- `config.contextMenu: { enabled, items }` — opt-in, default disabled.
- `table.openContextMenu(scope, context)` appends an `<ul role=\"menu\">` with one `<li role=\"menuitem\">` per visible item to `document.body`.
  - Honours per-item `scope` (`'row'` / `'header'` / `'cell'` / `'all'`)
  - `visible({ context })` predicate omits items
  - `disabled({ context })` renders `aria-disabled=\"true\"` and skips `onClick`
- `'separator'` string entries render `<li role=\"separator\">` with no text.
- `table.closeContextMenu()` removes the menu; no-op when nothing is open.
- `onClick` handlers are wrapped in `try/catch` + `console.warn`-ed so a single bad item cannot blow up the menu.

## Out of scope (still tracked on #44)
- Default items per scope (row → Edit / Delete; header → Sort asc/desc, Hide column; cell → Copy value)
- `contextmenu` event listener that dispatches to `openContextMenu` with click coordinates
- Keyboard navigation (Arrow keys, Enter / Space, Escape)
- Touch long-press (≥ 500ms) trigger
- Viewport-flip positioning when the menu would overflow
- Focus management (return focus to the trigger on close)

## Tests
New file `test/context-menu.test.js` — 9 cases:
- Disabled by default — `openContextMenu` is a no-op
- Renders `<ul role=\"menu\">` and one `<li role=\"menuitem\">` per item
- Click invokes `onClick({ context })` with the right shape
- `visible: false` omits an item
- `disabled: true` adds `aria-disabled` and skips `onClick`
- `item.scope` filters which scopes show the item
- `'separator'` renders `<li role=\"separator\">`
- `closeContextMenu()` removes the menu
- `closeContextMenu()` no-op when nothing is open

Full suite: 70/71 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #44