### PR TITLE
feat(context-menu): wire contextmenu event + Escape / outside-click dismissal

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -830,6 +830,12 @@ class TableCrafter {
     table.appendChild(tbody);
     tableContainer.appendChild(table);
 
+    // Wire contextmenu listener once per render — delegates to openContextMenu
+    // by scope (header / row / cell) when contextMenu.enabled is true.
+    if (typeof this._wireContextMenuEvents === 'function') {
+      this._wireContextMenuEvents(table);
+    }
+
     return tableContainer;
   }
 
@@ -2781,6 +2787,19 @@ class TableCrafter {
 
     document.body.appendChild(menu);
     this._contextMenu = menu;
+
+    // Dismissal: Escape + outside-click. Attached lazily; torn down in close.
+    const onKeyDown = (ev) => {
+      if (ev.key === 'Escape') this.closeContextMenu();
+    };
+    const onDocClick = (ev) => {
+      if (this._contextMenu && !this._contextMenu.contains(ev.target)) {
+        this.closeContextMenu();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('click', onDocClick);
+    this._contextMenuListeners = { onKeyDown, onDocClick };
   }
 
   closeContextMenu() {
@@ -2788,6 +2807,56 @@ class TableCrafter {
       this._contextMenu.parentNode.removeChild(this._contextMenu);
     }
     this._contextMenu = null;
+    if (this._contextMenuListeners) {
+      document.removeEventListener('keydown', this._contextMenuListeners.onKeyDown);
+      document.removeEventListener('click', this._contextMenuListeners.onDocClick);
+      this._contextMenuListeners = null;
+    }
+  }
+
+  /**
+   * Attach a contextmenu listener to the rendered table that delegates by
+   * scope (header / row / cell) and supplies the context payload. Called
+   * once per render after the table DOM is in place.
+   */
+  _wireContextMenuEvents(tableEl) {
+    if (!tableEl || !this.config.contextMenu || !this.config.contextMenu.enabled) return;
+    if (tableEl._tcContextMenuWired) return;
+    tableEl._tcContextMenuWired = true;
+
+    tableEl.addEventListener('contextmenu', (ev) => {
+      const target = ev.target;
+      const td = target.closest && target.closest('td');
+      const th = target.closest && target.closest('th');
+      const tr = target.closest && target.closest('tr');
+
+      if (th) {
+        ev.preventDefault();
+        this.openContextMenu('header', { field: th.dataset.field || null });
+        return;
+      }
+      if (td) {
+        ev.preventDefault();
+        const rowIndex = tr ? Number(tr.dataset.rowIndex) : null;
+        const field = td.dataset.field || null;
+        const row = (rowIndex != null && this.data[rowIndex]) || null;
+        this.openContextMenu('cell', {
+          rowIndex,
+          field,
+          row,
+          value: row && field ? row[field] : undefined
+        });
+        return;
+      }
+      if (tr) {
+        ev.preventDefault();
+        const rowIndex = Number(tr.dataset.rowIndex);
+        this.openContextMenu('row', {
+          rowIndex,
+          row: this.data[rowIndex] || null
+        });
+      }
+    });
   }
 
   /**

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -107,6 +107,13 @@ class TableCrafter {
         headers: {},
         authentication: null
       },
+      // Context menu configuration (foundation only — event-listener wiring,
+      // keyboard navigation, touch long-press, and viewport-flip positioning
+      // are tracked in #44 follow-ups)
+      contextMenu: {
+        enabled: false,
+        items: []
+      },
       // Permission system configuration
       permissions: {
         enabled: false,
@@ -2705,6 +2712,83 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Open a context menu at the document level (positioning is the caller's
+   * responsibility for now — viewport-flip + click coordinates land in a
+   * follow-up). Resolves item visibility / disabled per the supplied context
+   * and supports per-item `scope` filtering.
+   *
+   * No-op when contextMenu.enabled is false.
+   */
+  openContextMenu(scope, context) {
+    const cfg = this.config && this.config.contextMenu;
+    if (!cfg || !cfg.enabled) return;
+    this.closeContextMenu();
+
+    const fullContext = Object.assign({ scope }, context || {});
+    const items = (cfg.items || []).filter(item => {
+      if (item === 'separator') return true;
+      if (!item) return false;
+      if (item.scope && item.scope !== 'all' && item.scope !== scope) return false;
+      if (typeof item.visible === 'function') {
+        try {
+          if (item.visible({ context: fullContext }) === false) return false;
+        } catch (e) {
+          return false;
+        }
+      }
+      return true;
+    });
+    if (items.length === 0) return;
+
+    const menu = document.createElement('ul');
+    menu.className = 'tc-context-menu';
+    menu.setAttribute('role', 'menu');
+
+    for (const item of items) {
+      if (item === 'separator') {
+        const sep = document.createElement('li');
+        sep.setAttribute('role', 'separator');
+        menu.appendChild(sep);
+        continue;
+      }
+      const li = document.createElement('li');
+      li.setAttribute('role', 'menuitem');
+      li.textContent = item.label || '';
+      let disabled = false;
+      if (typeof item.disabled === 'function') {
+        try {
+          disabled = item.disabled({ context: fullContext }) === true;
+        } catch (e) {
+          disabled = true;
+        }
+      }
+      if (disabled) li.setAttribute('aria-disabled', 'true');
+      li.addEventListener('click', () => {
+        if (disabled) return;
+        try {
+          if (typeof item.onClick === 'function') {
+            item.onClick({ context: fullContext });
+          }
+        } catch (e) {
+          console.warn('TableCrafter contextMenu: onClick threw', e);
+        }
+        this.closeContextMenu();
+      });
+      menu.appendChild(li);
+    }
+
+    document.body.appendChild(menu);
+    this._contextMenu = menu;
+  }
+
+  closeContextMenu() {
+    if (this._contextMenu && this._contextMenu.parentNode) {
+      this._contextMenu.parentNode.removeChild(this._contextMenu);
+    }
+    this._contextMenu = null;
+  }
 
   /**
    * Set current user context

--- a/test/context-menu-events.test.js
+++ b/test/context-menu-events.test.js
@@ -1,0 +1,158 @@
+/**
+ * Context menu event wiring (slice 2 of #44).
+ * Stacked on PR #105 (programmatic openContextMenu / closeContextMenu).
+ *
+ * - contextmenu event on <tr> / <th> / <td> opens the menu, calls
+ *   preventDefault, infers scope from the target, and supplies context
+ *   ({ rowIndex, field, row, value }).
+ * - Outside click and Escape close the menu.
+ * - Native context menu is not replaced when contextMenu.enabled is false.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }],
+    contextMenu: {
+      enabled: true,
+      items: [{ id: 'a', label: 'Action', onClick: () => {} }]
+    },
+    ...extra
+  });
+}
+
+afterEach(() => {
+  document.querySelectorAll('.tc-context-menu').forEach(el => el.remove());
+});
+
+function dispatchContextMenu(target) {
+  const ev = new Event('contextmenu', { bubbles: true, cancelable: true });
+  ev.preventDefault = jest.fn();
+  ev.clientX = 100;
+  ev.clientY = 200;
+  target.dispatchEvent(ev);
+  return ev;
+}
+
+describe('contextmenu event wiring', () => {
+  test('right-click on a <td> opens the menu with cell scope and context', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'cell', label: 'Cell action', onClick, scope: 'cell' }]
+      }
+    });
+    table.render();
+
+    const td = document.querySelector('td[data-field="name"]');
+    const ev = dispatchContextMenu(td);
+
+    expect(ev.preventDefault).toHaveBeenCalled();
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0][0].context).toEqual(
+      expect.objectContaining({ scope: 'cell', field: 'name', rowIndex: 0, value: 'A' })
+    );
+  });
+
+  test('right-click on a <th> opens the menu with header scope', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'h', label: 'Header action', onClick, scope: 'header' }]
+      }
+    });
+    table.render();
+
+    const th = document.querySelector('thead th');
+    dispatchContextMenu(th);
+
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+    expect(onClick.mock.calls[0][0].context.scope).toBe('header');
+  });
+
+  test('right-click on a <tr> (not on a <td>) opens with row scope', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'r', label: 'Row action', onClick, scope: 'row' }]
+      }
+    });
+    table.render();
+
+    const tr = document.querySelectorAll('tbody tr')[1];
+    // Dispatch on tr itself rather than a child td. The handler should
+    // fall back to row scope.
+    const ev = new Event('contextmenu', { bubbles: true, cancelable: true });
+    ev.preventDefault = jest.fn();
+    Object.defineProperty(ev, 'target', { value: tr });
+    tr.dispatchEvent(ev);
+
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+    expect(onClick.mock.calls[0][0].context).toEqual(
+      expect.objectContaining({ scope: 'row', rowIndex: 1 })
+    );
+  });
+
+  test('contextmenu does NOT preventDefault when contextMenu.enabled is false', () => {
+    document.body.innerHTML = '<div id="t"></div>';
+    const table = new TableCrafter('#t', {
+      columns: [{ field: 'name' }],
+      data: [{ name: 'A' }]
+    });
+    table.render();
+
+    const td = document.querySelector('td[data-field="name"]');
+    const ev = dispatchContextMenu(td);
+
+    expect(ev.preventDefault).not.toHaveBeenCalled();
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+});
+
+describe('Context menu dismissal', () => {
+  test('Escape closes the menu', () => {
+    const table = makeTable();
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+
+    const ev = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(ev);
+
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+
+  test('outside click closes the menu', () => {
+    const table = makeTable();
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.click();
+
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+
+  test('click inside the menu does not close it before the item handler runs', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Action', onClick }]
+      }
+    });
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/context-menu.test.js
+++ b/test/context-menu.test.js
@@ -1,0 +1,176 @@
+/**
+ * Context menu — programmatic foundation (slice 1 of #44).
+ *
+ * Lands the config surface, `openContextMenu(scope, context)`,
+ * `closeContextMenu()`, and the public `menuItems` resolution. The actual
+ * `contextmenu` event listener wiring, keyboard navigation, touch long-press,
+ * and viewport-flip positioning are deferred to follow-up PRs and remain
+ * tracked on #44.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }],
+    ...extra
+  });
+}
+
+afterEach(() => {
+  document.querySelectorAll('.tc-context-menu').forEach(el => el.remove());
+});
+
+describe('Context menu: disabled by default', () => {
+  test('openContextMenu does nothing when contextMenu.enabled is false (default)', () => {
+    const table = makeTable();
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+});
+
+describe('Context menu: custom items', () => {
+  test('renders <ul role="menu"> with one <li role="menuitem"> per item', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick },
+          { id: 'b', label: 'Beta',  onClick }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    const menu = document.querySelector('.tc-context-menu');
+    expect(menu).not.toBeNull();
+    expect(menu.getAttribute('role')).toBe('menu');
+
+    const items = menu.querySelectorAll('li[role="menuitem"]');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('Alpha');
+    expect(items[1].textContent).toBe('Beta');
+  });
+
+  test('clicking an item invokes onClick with { context }', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 1, row: { id: 2, name: 'B' } });
+    document.querySelector('.tc-context-menu li[role="menuitem"]').click();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0][0].context).toEqual(
+      expect.objectContaining({ scope: 'row', rowIndex: 1, row: { id: 2, name: 'B' } })
+    );
+  });
+
+  test('visible: false omits the item', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick: () => {} },
+          { id: 'b', label: 'Beta',  onClick: () => {}, visible: () => false }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const items = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe('Alpha');
+  });
+
+  test('disabled: true marks the item aria-disabled and skips onClick', () => {
+    const onClick = jest.fn();
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick, disabled: () => true }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const item = document.querySelector('.tc-context-menu li[role="menuitem"]');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+
+    item.click();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('item.scope filters which scopes show the item', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'r', label: 'Row only',    onClick: () => {}, scope: 'row' },
+          { id: 'h', label: 'Header only', onClick: () => {}, scope: 'header' },
+          { id: 'a', label: 'Anywhere',    onClick: () => {} }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    let labels = Array.from(document.querySelectorAll('.tc-context-menu li')).map(li => li.textContent);
+    expect(labels).toEqual(['Row only', 'Anywhere']);
+
+    table.closeContextMenu();
+    table.openContextMenu('header', { field: 'name' });
+    labels = Array.from(document.querySelectorAll('.tc-context-menu li')).map(li => li.textContent);
+    expect(labels).toEqual(['Header only', 'Anywhere']);
+  });
+});
+
+describe('Context menu: separator', () => {
+  test('"separator" entries render an <li role="separator"> without text', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [
+          { id: 'a', label: 'Alpha', onClick: () => {} },
+          'separator',
+          { id: 'b', label: 'Beta',  onClick: () => {} }
+        ]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    const seps = document.querySelectorAll('.tc-context-menu li[role="separator"]');
+    expect(seps).toHaveLength(1);
+    expect(seps[0].textContent.trim()).toBe('');
+  });
+});
+
+describe('Context menu: closeContextMenu()', () => {
+  test('removes the menu from the DOM', () => {
+    const table = makeTable({
+      contextMenu: {
+        enabled: true,
+        items: [{ id: 'a', label: 'Alpha', onClick: () => {} }]
+      }
+    });
+
+    table.openContextMenu('row', { rowIndex: 0 });
+    expect(document.querySelector('.tc-context-menu')).not.toBeNull();
+
+    table.closeContextMenu();
+    expect(document.querySelector('.tc-context-menu')).toBeNull();
+  });
+
+  test('closeContextMenu when no menu is open is a no-op', () => {
+    const table = makeTable({
+      contextMenu: { enabled: true, items: [{ id: 'a', label: 'Alpha', onClick: () => {} }] }
+    });
+    expect(() => table.closeContextMenu()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #105 (programmatic `openContextMenu` / `closeContextMenu`). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #105 merges.

- `_wireContextMenuEvents(tableEl)` attaches a `contextmenu` listener once per render. Delegates to `openContextMenu` by walking the event target ancestry:
  - `<th>` → `header` scope (with `field`)
  - `<td>` → `cell` scope (with `rowIndex`, `field`, `row`, `value`)
  - `<tr>` → `row` scope (with `rowIndex`, `row`)
  Each path calls `preventDefault` before opening so the native browser menu does not race the rendered one.
- `openContextMenu` now arms two document listeners and tears them down in `closeContextMenu`:
  - `keydown`: Escape closes the menu.
  - `click`: closes when the click target is outside the menu DOM. Item clicks bubble through and fire `onClick` first, then close via the existing item handler so the outside-click path does not race `onClick`.
- When `contextMenu.enabled` is false, no listener is attached and the browser's native context menu is unaffected.

## Out of scope (still tracked on #44)
- Default per-scope items (row → Edit / Delete; header → Sort asc / Sort desc / Hide column; cell → Copy value)
- Keyboard arrow navigation inside the menu
- Touch long-press (≥ 500ms) trigger
- Focus management (focus first item on open, return focus to trigger on close)
- Viewport-flip positioning when the menu would overflow

## Tests
New file `test/context-menu-events.test.js` — 7 cases:
- Right-click on `<td>` opens with cell scope and the right context payload
- Right-click on `<th>` opens with header scope
- Right-click on `<tr>` (no inner `<td>`) opens with row scope
- `contextMenu.enabled: false` does NOT call `preventDefault`
- Escape closes the menu
- Outside click closes the menu
- Click inside the menu still fires the item's `onClick`

Combined with the 9 foundation tests from PR #105: 16/16 context-menu tests green. Full suite: 77/78 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #44