### PR TITLE
feat(context-menu): keyboard navigation (Arrow / Enter / Space, focus on open)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2788,9 +2788,51 @@ class TableCrafter {
     document.body.appendChild(menu);
     this._contextMenu = menu;
 
-    // Dismissal: Escape + outside-click. Attached lazily; torn down in close.
+    // Make menuitems focusable and put initial focus on the first enabled one.
+    const menuItems = menu.querySelectorAll('li[role="menuitem"]');
+    menuItems.forEach(li => li.setAttribute('tabindex', '-1'));
+    const firstEnabled = Array.from(menuItems).find(li => li.getAttribute('aria-disabled') !== 'true');
+    if (firstEnabled) firstEnabled.focus();
+
+    const focusableItems = () =>
+      Array.from(menu.querySelectorAll('li[role="menuitem"]'))
+        .filter(li => li.getAttribute('aria-disabled') !== 'true');
+
+    const moveFocus = (dir) => {
+      const list = focusableItems();
+      if (list.length === 0) return;
+      const cur = list.indexOf(document.activeElement);
+      let next;
+      if (cur === -1) next = 0;
+      else next = (cur + dir + list.length) % list.length;
+      list[next].focus();
+    };
+
+    // Dismissal: Escape + outside-click + keyboard navigation. Attached
+    // lazily; torn down in close.
     const onKeyDown = (ev) => {
-      if (ev.key === 'Escape') this.closeContextMenu();
+      if (ev.key === 'Escape') {
+        this.closeContextMenu();
+        return;
+      }
+      if (ev.key === 'ArrowDown') {
+        ev.preventDefault();
+        moveFocus(1);
+        return;
+      }
+      if (ev.key === 'ArrowUp') {
+        ev.preventDefault();
+        moveFocus(-1);
+        return;
+      }
+      if (ev.key === 'Enter' || ev.key === ' ') {
+        const focused = document.activeElement;
+        if (focused && menu.contains(focused) && focused.getAttribute('role') === 'menuitem'
+            && focused.getAttribute('aria-disabled') !== 'true') {
+          ev.preventDefault();
+          focused.click();
+        }
+      }
     };
     const onDocClick = (ev) => {
       if (this._contextMenu && !this._contextMenu.contains(ev.target)) {

--- a/test/context-menu-keyboard.test.js
+++ b/test/context-menu-keyboard.test.js
@@ -1,0 +1,119 @@
+/**
+ * Context menu keyboard navigation (slice 3 of #44).
+ * Stacked on PR #106 (event wiring + Escape / outside-click dismissal).
+ *
+ * - First menuitem receives focus when the menu opens.
+ * - ArrowDown / ArrowUp cycle focus among menuitems, skipping separators
+ *   and aria-disabled items.
+ * - Enter and Space activate the focused item (calls onClick).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(items) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }],
+    data: [{ id: 1 }],
+    contextMenu: { enabled: true, items }
+  });
+}
+
+afterEach(() => {
+  document.querySelectorAll('.tc-context-menu').forEach(el => el.remove());
+});
+
+function press(key) {
+  const ev = new KeyboardEvent('keydown', { key, bubbles: true });
+  document.activeElement.dispatchEvent(ev);
+  return ev;
+}
+
+describe('Context menu: keyboard navigation', () => {
+  test('first menuitem is focused on open', () => {
+    const table = makeTable([
+      { id: 'a', label: 'Alpha', onClick: () => {} },
+      { id: 'b', label: 'Beta',  onClick: () => {} }
+    ]);
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    const items = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  test('ArrowDown moves focus to the next item, ArrowUp to previous', () => {
+    const table = makeTable([
+      { id: 'a', label: 'Alpha', onClick: () => {} },
+      { id: 'b', label: 'Beta',  onClick: () => {} },
+      { id: 'c', label: 'Gamma', onClick: () => {} }
+    ]);
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    const items = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+    press('ArrowDown');
+    expect(document.activeElement).toBe(items[1]);
+    press('ArrowDown');
+    expect(document.activeElement).toBe(items[2]);
+    press('ArrowUp');
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  test('ArrowDown wraps to the first item past the end; ArrowUp wraps to the last', () => {
+    const table = makeTable([
+      { id: 'a', label: 'Alpha', onClick: () => {} },
+      { id: 'b', label: 'Beta',  onClick: () => {} }
+    ]);
+    table.openContextMenu('row', { rowIndex: 0 });
+    const items = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+
+    // Wrap forward.
+    press('ArrowDown'); // → 1
+    press('ArrowDown'); // wraps → 0
+    expect(document.activeElement).toBe(items[0]);
+
+    // Wrap backward.
+    press('ArrowUp'); // wraps → last
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  test('separators and aria-disabled items are skipped during navigation', () => {
+    const table = makeTable([
+      { id: 'a', label: 'Alpha', onClick: () => {} },
+      'separator',
+      { id: 'b', label: 'Beta',  onClick: () => {}, disabled: () => true },
+      { id: 'c', label: 'Gamma', onClick: () => {} }
+    ]);
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    const allMenuitems = document.querySelectorAll('.tc-context-menu li[role="menuitem"]');
+    const enabled = Array.from(allMenuitems).filter(li => li.getAttribute('aria-disabled') !== 'true');
+
+    expect(document.activeElement).toBe(enabled[0]);
+    press('ArrowDown');
+    expect(document.activeElement).toBe(enabled[1]); // skipped the disabled one
+  });
+
+  test('Enter activates the focused item', () => {
+    const onClick = jest.fn();
+    const table = makeTable([
+      { id: 'a', label: 'Alpha', onClick: () => {} },
+      { id: 'b', label: 'Beta',  onClick }
+    ]);
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    press('ArrowDown'); // focus on Beta
+    press('Enter');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('Space activates the focused item', () => {
+    const onClick = jest.fn();
+    const table = makeTable([{ id: 'a', label: 'Alpha', onClick }]);
+    table.openContextMenu('row', { rowIndex: 0 });
+
+    press(' ');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #106 (event wiring + Escape / outside-click). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #106 merges.

- Menuitems get `tabindex=\"-1\"` and the first enabled item receives focus the moment the menu opens.
- ArrowDown / ArrowUp cycle focus among focusable menuitems, wrapping at the ends. Separators and `aria-disabled` items are skipped so navigation only lands on actionable entries.
- Enter / Space on a focused menuitem activate it via the existing click handler (which fires `onClick` and closes the menu).
- All key handling routes through the same document `keydown` listener registered alongside the Escape dismissal — listener lifecycle is unchanged: armed on open, torn down in close.

## Out of scope (still tracked on #44)
- Touch long-press (≥ 500ms) trigger to open
- Focus management on close (return focus to the contextmenu trigger)
- Viewport-flip positioning when the menu would overflow
- `aria-haspopup=\"menu\"` on the trigger row / header / cell

## Tests
New file `test/context-menu-keyboard.test.js` — 6 cases:
- First menuitem focused on open
- ArrowDown / ArrowUp cycle focus
- Wrap forward and backward at the ends
- Separators and `aria-disabled` items are skipped
- Enter activates the focused item
- Space activates the focused item

Combined: 22/22 context-menu tests green (9 foundation + 7 events + 6 keyboard). Full suite: 83/84 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #44