### PR TITLE
feat(search): savePreset / removePreset / applyPreset / getPresets API

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2855,6 +2855,71 @@ class TableCrafter {
   }
 
   /**
+   * Defensive snapshot of the configured search presets.
+   */
+  getPresets() {
+    const presets = (this.config && this.config.search && this.config.search.presets) || [];
+    return presets.map(p => ({ ...p }));
+  }
+
+  /**
+   * Persist a preset. Three call shapes:
+   *   - savePreset(label) — uses the current query (this.searchTerm).
+   *   - savePreset(label, query) — explicit query string.
+   *   - savePreset({ id, label, query }) — full record. If `id` matches an
+   *     existing preset, that entry is replaced rather than appended.
+   * Throws on empty label.
+   */
+  savePreset(labelOrRecord, query) {
+    const search = this._ensureSearchConfig();
+    let record;
+    if (labelOrRecord && typeof labelOrRecord === 'object') {
+      record = { ...labelOrRecord };
+    } else {
+      record = {
+        label: labelOrRecord,
+        query: typeof query === 'string' ? query : (this.searchTerm || '')
+      };
+    }
+    if (!record.label || typeof record.label !== 'string') {
+      throw new Error('TableCrafter: savePreset requires a non-empty label');
+    }
+    if (!record.id) {
+      record.id = `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    const idx = search.presets.findIndex(p => p.id === record.id);
+    if (idx !== -1) {
+      search.presets[idx] = record;
+    } else {
+      search.presets.push(record);
+    }
+    return record;
+  }
+
+  removePreset(id) {
+    const search = this._ensureSearchConfig();
+    const before = search.presets.length;
+    search.presets = search.presets.filter(p => p.id !== id);
+    return search.presets.length < before;
+  }
+
+  applyPreset(id) {
+    const presets = (this.config && this.config.search && this.config.search.presets) || [];
+    const preset = presets.find(p => p.id === id);
+    if (!preset) return false;
+    this.setQuery(preset.query || '');
+    return true;
+  }
+
+  _ensureSearchConfig() {
+    if (!this.config) this.config = {};
+    if (!this.config.search) this.config.search = {};
+    if (!Array.isArray(this.config.search.presets)) this.config.search.presets = [];
+    return this.config.search;
+  }
+
+  /**
    * Programmatically apply a search query string. Empty / falsy clears the
    * active query. Triggers a re-render so the filtered set is visible.
    */

--- a/test/search-presets.test.js
+++ b/test/search-presets.test.js
@@ -1,0 +1,121 @@
+/**
+ * Search presets API: savePreset / removePreset / config.search.presets.
+ * Slice 6 of #59. Stacked on PR #91 (regex literals).
+ *
+ * Lands the public API and the underlying state. UI rendering of preset
+ * chips and persistence integration with state-saving remain queued.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }],
+    ...extra
+  });
+}
+
+describe('config.search.presets', () => {
+  test('getPresets() returns a defensive copy of configured presets', () => {
+    const table = makeTable({
+      search: { presets: [{ id: 'mine', label: 'My open items', query: 'status:open' }] }
+    });
+
+    const list = table.getPresets();
+    expect(list).toEqual([{ id: 'mine', label: 'My open items', query: 'status:open' }]);
+
+    list.length = 0;
+    expect(table.getPresets()).toHaveLength(1);
+  });
+
+  test('getPresets() returns [] when no presets configured', () => {
+    const table = makeTable();
+    expect(table.getPresets()).toEqual([]);
+  });
+});
+
+describe('savePreset(label, query?)', () => {
+  test('persists the current query as a new preset and returns it', () => {
+    const table = makeTable();
+    table.setQuery('status:open');
+
+    const saved = table.savePreset('Open');
+
+    expect(saved.label).toBe('Open');
+    expect(saved.query).toBe('status:open');
+    expect(saved.id).toBeTruthy();
+    expect(table.getPresets().map(p => p.label)).toEqual(['Open']);
+  });
+
+  test('an explicit query argument overrides the current query', () => {
+    const table = makeTable();
+    table.setQuery('something else');
+    table.savePreset('Specific', 'role:=admin');
+    expect(table.getPresets()[0].query).toBe('role:=admin');
+  });
+
+  test('save with the same id replaces the existing preset', () => {
+    const table = makeTable({
+      search: { presets: [{ id: 'fixed', label: 'Old', query: 'old' }] }
+    });
+
+    table.savePreset({ id: 'fixed', label: 'New', query: 'new' });
+
+    const list = table.getPresets();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toEqual({ id: 'fixed', label: 'New', query: 'new' });
+  });
+
+  test('rejects empty label', () => {
+    const table = makeTable();
+    table.setQuery('foo');
+    expect(() => table.savePreset('')).toThrow(/label/i);
+    expect(() => table.savePreset(null)).toThrow(/label/i);
+  });
+});
+
+describe('removePreset(id)', () => {
+  test('removes the matching preset and returns true', () => {
+    const table = makeTable({
+      search: {
+        presets: [
+          { id: 'a', label: 'Alpha', query: 'x' },
+          { id: 'b', label: 'Beta',  query: 'y' }
+        ]
+      }
+    });
+
+    expect(table.removePreset('a')).toBe(true);
+    expect(table.getPresets().map(p => p.id)).toEqual(['b']);
+  });
+
+  test('returns false when no preset matches', () => {
+    const table = makeTable({
+      search: { presets: [{ id: 'a', label: 'Alpha', query: 'x' }] }
+    });
+    expect(table.removePreset('ghost')).toBe(false);
+    expect(table.getPresets()).toHaveLength(1);
+  });
+});
+
+describe('applyPreset(id)', () => {
+  test('applies the preset query via setQuery and returns true', () => {
+    const table = makeTable({
+      search: { presets: [{ id: 'mobile', label: 'Mobile', query: 'team:mobile' }] },
+      data: [
+        { id: 1, name: 'Alice', team: 'core' },
+        { id: 2, name: 'Bob',   team: 'mobile' }
+      ]
+    });
+
+    expect(table.applyPreset('mobile')).toBe(true);
+    expect(table.getFilteredData().map(r => r.id)).toEqual([2]);
+  });
+
+  test('returns false for an unknown id', () => {
+    const table = makeTable();
+    expect(table.applyPreset('ghost')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #91 (regex literals). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #91 merges.

Lands the public preset API for #59 AC item 4.

- `config.search.presets: Array<{ id, label, query }>` — auto-loaded as the initial list.
- `getPresets()` returns a defensive copy.
- `savePreset(label)` saves the current query under the given label.
- `savePreset(label, query)` saves an explicit query.
- `savePreset({ id, label, query })` — full record; matching `id` replaces the existing entry rather than appending.
- Auto-generates an `id` when omitted; throws on empty `label`.
- `removePreset(id)` returns `true` / `false`.
- `applyPreset(id)` routes through `setQuery`, so the AST / evaluator path drives the filter.

## Out of scope (still tracked in #59)
- UI rendering of preset chips below the search input
- Persistence integration with the existing state-saving layer
- Suggestions dropdown (`config.search.suggestions`)
- Query builder modal (`config.search.builder`)

## Tests
New file `test/search-presets.test.js` — 10 cases:
- `getPresets()` returns a defensive copy / `[]` for unconfigured
- `savePreset(label)` uses `searchTerm`
- Explicit query overrides the current one
- Save with same `id` replaces
- Empty label throws
- `removePreset` returns `true` on hit, `false` on miss
- `applyPreset` updates the filter via `setQuery`
- `applyPreset` returns `false` for unknown id

Combined: 60/60 search tests green (14 parser + 11 evaluator + 11 comparisons + 8 wildcards + 6 regex + 10 presets). Full suite: 121/122 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #59