### PR TITLE
feat(columns): hidden flag + column-management public API

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -776,7 +776,7 @@ class TableCrafter {
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
 
-    this.config.columns.forEach(column => {
+    this.config.columns.filter(col => col.hidden !== true).forEach(column => {
       const th = document.createElement('th');
       th.setAttribute('scope', 'col');
       th.textContent = column.label;
@@ -846,7 +846,7 @@ class TableCrafter {
         const tr = document.createElement('tr');
         tr.dataset.rowIndex = actualRowIndex;
 
-        const columnPromises = this.config.columns.map(async (column) => {
+        const columnPromises = this.config.columns.filter(col => col.hidden !== true).map(async (column) => {
           const td = document.createElement('td');
 
           // Format lookup values
@@ -916,20 +916,21 @@ class TableCrafter {
   getVisibleFields(breakpoint) {
     const visibility = this.config.responsive.fieldVisibility || {};
     const breakpointConfig = visibility[breakpoint];
+    const cols = this.config.columns.filter(col => col.hidden !== true);
 
     if (!breakpointConfig) {
-      return this.config.columns;
+      return cols;
     }
 
     if (breakpointConfig.showFields) {
-      return this.config.columns.filter(col => breakpointConfig.showFields.includes(col.field));
+      return cols.filter(col => breakpointConfig.showFields.includes(col.field));
     }
 
     if (breakpointConfig.hideFields) {
-      return this.config.columns.filter(col => !breakpointConfig.hideFields.includes(col.field));
+      return cols.filter(col => !breakpointConfig.hideFields.includes(col.field));
     }
 
-    return this.config.columns;
+    return cols;
   }
 
   /**
@@ -3402,6 +3403,41 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  setColumnVisibility(field, visible) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    if (!column) {
+      throw new Error(`TableCrafter: setColumnVisibility — unknown field "${field}"`);
+    }
+    column.hidden = !visible;
+    this.render();
+  }
+
+  setColumnOrder(fields) {
+    if (!Array.isArray(fields)) return;
+    const cols = this.config.columns || [];
+    const byField = new Map(cols.map(c => [c.field, c]));
+    const used = new Set();
+    const reordered = [];
+
+    for (const field of fields) {
+      const col = byField.get(field);
+      if (col && !used.has(field)) {
+        reordered.push(col);
+        used.add(field);
+      }
+    }
+    for (const col of cols) {
+      if (!used.has(col.field)) reordered.push(col);
+    }
+
+    this.config.columns = reordered;
+    this.render();
+  }
+
+  getVisibleColumns() {
+    return (this.config.columns || []).filter(col => col.hidden !== true).slice();
   }
 
   /**

--- a/test/column-management.test.js
+++ b/test/column-management.test.js
@@ -1,0 +1,122 @@
+/**
+ * Column management foundation (slice 1 of #52).
+ *
+ * Lands the public state API: setColumnVisibility, setColumnOrder,
+ * getVisibleColumns, and the column.hidden filter in render. Drag-to-
+ * reorder UI, a "Manage columns" overlay, and pinned-columns sticky
+ * behaviour remain queued (#52 / #50 / #53 follow-ups).
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [{ id: 1, name: 'Alice', email: 'a@x' }, { id: 2, name: 'Bob', email: 'b@x' }];
+const columns = [
+  { field: 'id',    label: 'ID' },
+  { field: 'name',  label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  const cfg = { data, columns, ...extra };
+  // Clone columns so per-test mutations (setColumnVisibility / setColumnOrder)
+  // do not leak through the module-level constant into the next test.
+  cfg.columns = (cfg.columns || []).map(c => ({ ...c }));
+  return new TableCrafter('#t', cfg);
+}
+
+describe('Column management: hidden flag in render', () => {
+  test('a column with hidden: true is omitted from the rendered table', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'id', label: 'ID' },
+        { field: 'name', label: 'Name', hidden: true },
+        { field: 'email', label: 'Email' }
+      ]
+    });
+    table.render();
+
+    expect(document.querySelectorAll('thead th')).toHaveLength(2);
+    expect(document.querySelector('th[data-field="name"]')).toBeNull();
+    expect(document.querySelector('td[data-field="name"]')).toBeNull();
+  });
+});
+
+describe('Column management: setColumnVisibility', () => {
+  test('hides a single column and re-renders without it', () => {
+    const table = makeTable();
+    table.render();
+    expect(document.querySelectorAll('thead th')).toHaveLength(3);
+
+    table.setColumnVisibility('name', false);
+    expect(document.querySelectorAll('thead th')).toHaveLength(2);
+    expect(document.querySelector('th[data-field="name"]')).toBeNull();
+  });
+
+  test('shows a previously hidden column', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'name', hidden: true },
+        { field: 'email' }
+      ]
+    });
+    table.render();
+    expect(document.querySelector('th[data-field="name"]')).toBeNull();
+
+    table.setColumnVisibility('name', true);
+    expect(document.querySelector('th[data-field="name"]')).not.toBeNull();
+  });
+
+  test('throws on unknown field', () => {
+    const table = makeTable();
+    expect(() => table.setColumnVisibility('ghost', false)).toThrow(/ghost|unknown/i);
+  });
+});
+
+describe('Column management: setColumnOrder', () => {
+  test('reorders the columns to match the supplied array', () => {
+    const table = makeTable();
+    table.render();
+    expect(Array.from(document.querySelectorAll('thead th')).map(th => th.textContent))
+      .toEqual(['ID', 'Name', 'Email']);
+
+    table.setColumnOrder(['email', 'id', 'name']);
+    expect(Array.from(document.querySelectorAll('thead th')).map(th => th.textContent))
+      .toEqual(['Email', 'ID', 'Name']);
+  });
+
+  test('fields not listed in the new order are appended at the end', () => {
+    const table = makeTable();
+    table.setColumnOrder(['email']);
+    expect(Array.from(document.querySelectorAll('thead th')).map(th => th.textContent))
+      .toEqual(['Email', 'ID', 'Name']);
+  });
+
+  test('unknown fields in the new order are silently skipped', () => {
+    const table = makeTable();
+    table.setColumnOrder(['email', 'ghost', 'id']);
+    expect(Array.from(document.querySelectorAll('thead th')).map(th => th.textContent))
+      .toEqual(['Email', 'ID', 'Name']);
+  });
+});
+
+describe('Column management: getVisibleColumns', () => {
+  test('returns the visible columns in current order', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'name', hidden: true },
+        { field: 'email' }
+      ]
+    });
+    expect(table.getVisibleColumns().map(c => c.field)).toEqual(['id', 'email']);
+  });
+
+  test('mutating the returned array does not affect internal state', () => {
+    const table = makeTable();
+    const list = table.getVisibleColumns();
+    list.length = 0;
+    expect(table.getVisibleColumns()).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #52. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR implements the foundation portion of that plan.

- `column.hidden: true | false` (default `false`). The render path filters hidden columns from headers, body cells, and the responsive cards view; `getVisibleFields(breakpoint)` is updated to drop hidden too so responsive breakpoints compose with the new flag.
- `setColumnVisibility(field, visible)` toggles a single column and re-renders. Throws on unknown field.
- `setColumnOrder(fields)` reorders the column list to match the supplied array. Fields not listed are appended at the end so a partial reorder cannot drop columns. Unknown fields in the input array are silently skipped.
- `getVisibleColumns()` returns a defensive copy of the visible-only subset in current order.

`getExportableColumns()` is intentionally untouched — `column.hidden` is a UI concern, `column.exportable` remains the export-side gate. A column hidden in the UI can still be exported.

## Out of scope (still tracked on #52 and adjacent issues)
- Drag-to-reorder UI for column headers (likely lives in #50, Visual Table Builder)
- A \"Manage columns\" overlay / chip strip
- Persistence integration with `config.statePersistence` so the hidden flags + order round-trip
- Sticky / pinned columns (covered separately by #53)

## Tests
New file `test/column-management.test.js` — 9 cases:
- `column.hidden: true` is filtered from `<thead>` and `<tbody>`
- `setColumnVisibility(field, false)` hides a column live
- `setColumnVisibility(field, true)` un-hides a column live
- Unknown field throws
- `setColumnOrder` reorders headers + body
- Fields not listed in the new order are appended at the end
- Unknown fields in the new order are silently skipped
- `getVisibleColumns()` returns the visible subset
- `getVisibleColumns()` is a defensive copy

Full suite: 70/71 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #52