### PR TITLE
feat(columns): pinned-column foundation (column.pinned + pinColumn API)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -776,14 +776,16 @@ class TableCrafter {
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
 
-    this.config.columns.filter(col => col.hidden !== true).forEach(column => {
+    this._orderedColumns().forEach(column => {
       const th = document.createElement('th');
       th.setAttribute('scope', 'col');
+      if (column.pinned === 'left') th.classList.add('tc-pinned-left');
+      else if (column.pinned === 'right') th.classList.add('tc-pinned-right');
       th.textContent = column.label;
       th.dataset.field = column.field;
 
       if (this.config.sortable && column.sortable !== false) {
-        th.className = 'tc-sortable';
+        th.classList.add('tc-sortable');
         th.tabIndex = 0; // Make focusable
 
         // Determine this column's role in the current sort.
@@ -846,8 +848,10 @@ class TableCrafter {
         const tr = document.createElement('tr');
         tr.dataset.rowIndex = actualRowIndex;
 
-        const columnPromises = this.config.columns.filter(col => col.hidden !== true).map(async (column) => {
+        const columnPromises = this._orderedColumns().map(async (column) => {
           const td = document.createElement('td');
+          if (column.pinned === 'left') td.classList.add('tc-pinned-left');
+          else if (column.pinned === 'right') td.classList.add('tc-pinned-right');
 
           // Format lookup values
           let displayValue = row[column.field];
@@ -3403,6 +3407,35 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  _orderedColumns() {
+    const cols = (this.config.columns || []).filter(c => c.hidden !== true);
+    const left = cols.filter(c => c.pinned === 'left');
+    const middle = cols.filter(c => c.pinned !== 'left' && c.pinned !== 'right');
+    const right = cols.filter(c => c.pinned === 'right');
+    return [...left, ...middle, ...right];
+  }
+
+  pinColumn(field, side) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    if (!column) {
+      throw new Error(`TableCrafter: pinColumn — unknown field "${field}"`);
+    }
+    if (side === 'left' || side === 'right') {
+      column.pinned = side;
+    } else {
+      delete column.pinned;
+    }
+    this.render();
+  }
+
+  getPinnedColumns() {
+    const cols = (this.config.columns || []).filter(c => c.hidden !== true);
+    return {
+      left: cols.filter(c => c.pinned === 'left').map(c => ({ ...c })),
+      right: cols.filter(c => c.pinned === 'right').map(c => ({ ...c }))
+    };
   }
 
   setColumnVisibility(field, visible) {

--- a/test/pinned-columns.test.js
+++ b/test/pinned-columns.test.js
@@ -1,0 +1,149 @@
+/**
+ * Pinned columns foundation (slice 1 of #53).
+ *
+ * - column.pinned: 'left' | 'right' | false (default false)
+ * - Render order: left-pinned, unpinned, right-pinned (each in declaration order)
+ * - tc-pinned-left / tc-pinned-right class on header + body cells
+ * - pinColumn(field, side) public API; getPinnedColumns() snapshot
+ *
+ * Sticky positioning CSS, scroll handling, drag-to-pin UI, and shadow / divider
+ * styling are intentionally consumer-side and remain queued under #53.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [{ id: 1, name: 'Alice', email: 'a@x', team: 'core' }];
+
+function makeTable(columns, extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  const cfg = { data, columns, ...extra };
+  cfg.columns = (cfg.columns || []).map(c => ({ ...c })); // clone to isolate tests
+  return new TableCrafter('#t', cfg);
+}
+
+function headerLabels() {
+  return Array.from(document.querySelectorAll('thead th')).map(th => th.textContent);
+}
+
+describe('Pinned columns: render order', () => {
+  test('left-pinned columns render first regardless of declaration position', () => {
+    const table = makeTable([
+      { field: 'id',    label: 'ID' },
+      { field: 'name',  label: 'Name' },
+      { field: 'email', label: 'Email', pinned: 'left' },
+      { field: 'team',  label: 'Team' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['Email', 'ID', 'Name', 'Team']);
+  });
+
+  test('right-pinned columns render last regardless of declaration position', () => {
+    const table = makeTable([
+      { field: 'id',    label: 'ID' },
+      { field: 'name',  label: 'Name', pinned: 'right' },
+      { field: 'email', label: 'Email' },
+      { field: 'team',  label: 'Team' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['ID', 'Email', 'Team', 'Name']);
+  });
+
+  test('left + right pins coexist with unpinned in the middle', () => {
+    const table = makeTable([
+      { field: 'id',    label: 'ID' },
+      { field: 'name',  label: 'Name', pinned: 'left' },
+      { field: 'email', label: 'Email' },
+      { field: 'team',  label: 'Team', pinned: 'right' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['Name', 'ID', 'Email', 'Team']);
+  });
+});
+
+describe('Pinned columns: classes', () => {
+  test('pinned headers carry tc-pinned-left / tc-pinned-right classes', () => {
+    const table = makeTable([
+      { field: 'id',    label: 'ID', pinned: 'left' },
+      { field: 'name',  label: 'Name' },
+      { field: 'email', label: 'Email', pinned: 'right' }
+    ]);
+    table.render();
+
+    const ths = document.querySelectorAll('thead th');
+    expect(ths[0].classList.contains('tc-pinned-left')).toBe(true);
+    expect(ths[2].classList.contains('tc-pinned-right')).toBe(true);
+    expect(ths[1].classList.contains('tc-pinned-left')).toBe(false);
+    expect(ths[1].classList.contains('tc-pinned-right')).toBe(false);
+  });
+
+  test('pinned body cells carry the same classes', () => {
+    const table = makeTable([
+      { field: 'id', label: 'ID', pinned: 'left' },
+      { field: 'name', label: 'Name' }
+    ]);
+    table.render();
+
+    const idTd = document.querySelector('td[data-field="id"]');
+    expect(idTd.classList.contains('tc-pinned-left')).toBe(true);
+  });
+});
+
+describe('pinColumn() / getPinnedColumns()', () => {
+  test('pinColumn(field, "left") moves a column to the front and re-renders', () => {
+    const table = makeTable([
+      { field: 'id', label: 'ID' },
+      { field: 'name', label: 'Name' },
+      { field: 'email', label: 'Email' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['ID', 'Name', 'Email']);
+
+    table.pinColumn('email', 'left');
+    expect(headerLabels()).toEqual(['Email', 'ID', 'Name']);
+  });
+
+  test('pinColumn(field, false) unpins a column and restores its original spot', () => {
+    const table = makeTable([
+      { field: 'id', label: 'ID' },
+      { field: 'name', label: 'Name', pinned: 'left' },
+      { field: 'email', label: 'Email' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['Name', 'ID', 'Email']);
+
+    table.pinColumn('name', false);
+    expect(headerLabels()).toEqual(['ID', 'Name', 'Email']);
+  });
+
+  test('pinColumn() throws on unknown field', () => {
+    const table = makeTable([{ field: 'id', label: 'ID' }]);
+    expect(() => table.pinColumn('ghost', 'left')).toThrow(/ghost|unknown/i);
+  });
+
+  test('getPinnedColumns returns { left, right } as defensive copies', () => {
+    const table = makeTable([
+      { field: 'id', label: 'ID', pinned: 'left' },
+      { field: 'name', label: 'Name' },
+      { field: 'email', label: 'Email', pinned: 'right' }
+    ]);
+    const snap = table.getPinnedColumns();
+    expect(snap.left.map(c => c.field)).toEqual(['id']);
+    expect(snap.right.map(c => c.field)).toEqual(['email']);
+
+    snap.left.length = 0;
+    expect(table.getPinnedColumns().left).toHaveLength(1);
+  });
+});
+
+describe('Pinned + hidden compose', () => {
+  test('a hidden + pinned column does not render', () => {
+    const table = makeTable([
+      { field: 'id', label: 'ID' },
+      { field: 'name', label: 'Name', pinned: 'left', hidden: true },
+      { field: 'email', label: 'Email' }
+    ]);
+    table.render();
+    expect(headerLabels()).toEqual(['ID', 'Email']);
+    expect(document.querySelector('th[data-field="name"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Slice 1 of #53. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR implements the data-model + render-order + class-hook portion of that plan so sticky positioning can be driven entirely from consumer CSS.

- `column.pinned: 'left' | 'right' | undefined`
- `_orderedColumns()` returns columns in render order: left-pinned (in declaration order), unpinned (in declaration order), right-pinned (in declaration order). Hidden columns are filtered first so `pinned + hidden` compose: a pinned + hidden column still does not render.
- Headers and body cells receive `tc-pinned-left` / `tc-pinned-right` classes so consumer CSS can apply `position: sticky` with the right offsets and shadow / divider styling.
- `pinColumn(field, side)` toggles pin state (`'left'` / `'right'` / `false` to unpin) and re-renders. Throws on unknown field.
- `getPinnedColumns()` returns `{ left: Column[], right: Column[] }` defensive copies in render order.

Drive-by fix: `th.className = 'tc-sortable'` is now `classList.add` so the sortable class no longer clobbers the pinned class on the same header.

## Out of scope (still tracked on #53)
- Sticky positioning CSS shipped from the library (offsets, shadow / divider)
- Scroll-shadow handling for left / right pinned bands
- Drag-to-pin gesture (likely lives with #50 / #52 column-management UI)
- Keyboard-driven \"Pin column\" command in the context menu (composes with #44 default items)

## Tests
New file `test/pinned-columns.test.js` — 10 cases:
- Left-pinned columns render first regardless of declaration position
- Right-pinned columns render last regardless of declaration position
- Mixed left + middle + right columns
- `tc-pinned-left` / `tc-pinned-right` classes on headers
- Same classes on body cells
- `pinColumn(field, 'left')` reorders live
- `pinColumn(field, false)` unpins and restores original spot
- Unknown field throws
- `getPinnedColumns()` is a defensive copy
- Pinned + hidden compose (pinned + hidden does not render)

Full suite: 71/72 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #53