### PR TITLE
feat(aggregation): column.aggregate config + getAggregates / aggregate API

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3409,6 +3409,46 @@ class TableCrafter {
     return tokens;
   }
 
+  getAggregates(rows) {
+    const source = Array.isArray(rows) ? rows : this.getFilteredData();
+    const out = {};
+    for (const column of (this.config.columns || [])) {
+      if (column.aggregate == null) continue;
+      out[column.field] = this._computeAggregate(column.aggregate, column.field, source);
+    }
+    return out;
+  }
+
+  aggregate(field, fn, rows) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    const op = fn != null ? fn : (column && column.aggregate);
+    if (op == null) return null;
+    const source = Array.isArray(rows) ? rows : this.getFilteredData();
+    return this._computeAggregate(op, field, source);
+  }
+
+  _computeAggregate(op, field, source) {
+    if (typeof op === 'function') {
+      const values = source.map(r => r[field]);
+      return op(values, source);
+    }
+    if (op === 'count') {
+      return source.filter(r => r[field] != null).length;
+    }
+    const numeric = source
+      .filter(r => r[field] != null)
+      .map(r => Number(r[field]))
+      .filter(n => !Number.isNaN(n));
+    if (numeric.length === 0) return null;
+    switch (op) {
+      case 'sum': return numeric.reduce((a, b) => a + b, 0);
+      case 'avg': return numeric.reduce((a, b) => a + b, 0) / numeric.length;
+      case 'min': return Math.min(...numeric);
+      case 'max': return Math.max(...numeric);
+      default:    return null;
+    }
+  }
+
   _orderedColumns() {
     const cols = (this.config.columns || []).filter(c => c.hidden !== true);
     const left = cols.filter(c => c.pinned === 'left');

--- a/test/aggregation.test.js
+++ b/test/aggregation.test.js
@@ -1,0 +1,105 @@
+/**
+ * Aggregation foundation (slice 1 of #48).
+ *
+ * Adds column.aggregate config + getAggregates() / aggregate() helpers.
+ * Footer-row UI, group-by per-group totals, and state persistence remain
+ * queued under #48 follow-ups.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, qty: 10, price: 5.5,   note: 'a'  },
+  { id: 2, qty: 20, price: 'n/a', note: null },
+  { id: 3, qty: 30, price: 7.0,   note: 'b'  },
+  { id: 4, qty: 0,  price: 12.5,  note: 'c'  }
+];
+
+function makeTable(columns) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('Aggregation: built-in operators', () => {
+  test('sum over numeric values', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.getAggregates().qty).toBe(60);
+  });
+
+  test('avg over numeric values, ignoring non-numeric', () => {
+    const t = makeTable([{ field: 'price', aggregate: 'avg' }]);
+    expect(t.getAggregates().price).toBeCloseTo((5.5 + 7.0 + 12.5) / 3);
+  });
+
+  test('count counts non-null cells', () => {
+    const t = makeTable([{ field: 'note', aggregate: 'count' }]);
+    expect(t.getAggregates().note).toBe(3); // null skipped
+  });
+
+  test('min and max ignore non-numeric cells', () => {
+    const t = makeTable([
+      { field: 'qty',   aggregate: 'min' },
+      { field: 'price', aggregate: 'max' }
+    ]);
+    const agg = t.getAggregates();
+    expect(agg.qty).toBe(0);
+    expect(agg.price).toBe(12.5);
+  });
+
+  test('numeric ops on a column with no numeric cells return null', () => {
+    const t = makeTable([{ field: 'note', aggregate: 'sum' }]);
+    expect(t.getAggregates().note).toBeNull();
+  });
+});
+
+describe('Aggregation: custom function', () => {
+  test('receives (values, rows) and the return value lands as-is', () => {
+    const fn = jest.fn((values, rows) => `${rows.length} rows / ${values.length} qtys`);
+    const t = makeTable([{ field: 'qty', aggregate: fn }]);
+
+    const agg = t.getAggregates();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toEqual([10, 20, 30, 0]);   // values
+    expect(fn.mock.calls[0][1]).toHaveLength(4);             // rows
+    expect(agg.qty).toBe('4 rows / 4 qtys');
+  });
+});
+
+describe('Aggregation: getAggregates() shape', () => {
+  test('only includes fields that declared aggregate', () => {
+    const t = makeTable([
+      { field: 'id' },
+      { field: 'qty', aggregate: 'sum' },
+      { field: 'price' }
+    ]);
+    expect(Object.keys(t.getAggregates())).toEqual(['qty']);
+  });
+
+  test('uses getFilteredData() when rows arg is omitted', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    t.searchTerm = 'b'; // 'b' only appears in row 3's note field
+    expect(t.getAggregates().qty).toBe(30); // qty of just row 3
+  });
+
+  test('honours an explicit rows argument', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.getAggregates([{ qty: 1 }, { qty: 2 }]).qty).toBe(3);
+  });
+});
+
+describe('aggregate() one-shot helper', () => {
+  test('honours the column-declared aggregate when no fn passed', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.aggregate('qty')).toBe(60);
+  });
+
+  test('explicit fn overrides the declared aggregate', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.aggregate('qty', 'avg')).toBe(15);
+  });
+
+  test('returns null when neither column nor explicit fn is configured', () => {
+    const t = makeTable([{ field: 'qty' }]);
+    expect(t.aggregate('qty')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #48. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR implements the public API portion of that plan.

- `column.aggregate: 'sum' | 'avg' | 'count' | 'min' | 'max' | (values, rows) => any`
- `table.getAggregates(rows?)` runs every column with a declared aggregate over the supplied rows (default `getFilteredData()`). Returns a map of `field → computed value`; only declared columns appear.
- `table.aggregate(field, fn?, rows?)` one-shot helper. `fn` defaults to the column's declared aggregate; `rows` defaults to `getFilteredData()`. Returns `null` when neither is configured.
- Numeric ops drop `null` / `undefined` / non-numeric cells silently. `Number(null) === 0` is filtered out before coercion so empty cells don't poison `sum` / `avg` / `min` / `max`. `null` is returned when nothing numeric remains.
- `count` counts non-null cells (numbers, strings, booleans).
- Custom function receives `(values, rows)` and its return value lands as-is, so consumers can roll up arbitrary types.

## Out of scope (still tracked on #48)
- Footer / summary-row UI rendering (separate ticket — likely lives with #50 Visual Table Builder)
- Group-by per-group aggregates (separate ticket; this PR covers whole-dataset only)
- State persistence of computed aggregates

## Tests
New file `test/aggregation.test.js` — 12 cases:
- Each built-in op (`sum` / `avg` / `count` / `min` / `max`) on a numeric fixture
- Numeric ops drop non-numeric cells silently
- Numeric ops with no numeric cells return `null` (no `Number(null) === 0` poisoning)
- `count` counts non-null cells (including non-numeric strings)
- Custom function receives `(values, rows)` and its return lands as-is
- `getAggregates()` only includes fields with `aggregate` declared
- Defaults to `getFilteredData()` when no `rows` argument
- Honours an explicit `rows` arg
- `aggregate(field)` honours the column's declared op
- `aggregate(field, 'avg')` overrides the declared op
- `aggregate(field)` returns `null` when nothing is configured

Full suite: 73/74 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #48