### PR TITLE
feat(formulas): safe expression evaluator (column.formula)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -853,9 +853,14 @@ class TableCrafter {
           if (column.pinned === 'left') td.classList.add('tc-pinned-left');
           else if (column.pinned === 'right') td.classList.add('tc-pinned-right');
 
-          // Format lookup values
-          let displayValue = row[column.field];
-          
+          let displayValue;
+          if (column.formula) {
+            const computed = this.evaluateFormula(column.formula, row);
+            displayValue = computed === null ? '' : computed;
+          } else {
+            displayValue = row[column.field];
+          }
+
           if (displayValue === null || displayValue === undefined) {
              displayValue = '';
           }
@@ -3407,6 +3412,143 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  evaluateFormula(formula, row) {
+    if (typeof formula !== 'string') return null;
+    if (!this._formulaWarned) this._formulaWarned = new Set();
+
+    const warnOnce = reason => {
+      const key = `${formula}|${reason}`;
+      if (!this._formulaWarned.has(key)) {
+        this._formulaWarned.add(key);
+        console.warn(`TableCrafter formula: ${reason} in "${formula}"`);
+      }
+    };
+
+    const tokens = this._tokenizeFormula(formula);
+    if (!tokens) {
+      warnOnce('disallowed token');
+      return null;
+    }
+
+    const resolved = [];
+    for (const tok of tokens) {
+      if (tok.type === 'placeholder') {
+        if (!row || !(tok.name in row)) return null;
+        const num = Number(row[tok.name]);
+        if (Number.isNaN(num)) return null;
+        resolved.push({ type: 'number', value: num });
+      } else {
+        resolved.push(tok);
+      }
+    }
+
+    const postfix = this._toPostfix(resolved);
+    if (!postfix) {
+      warnOnce('mismatched parentheses');
+      return null;
+    }
+
+    const result = this._evaluatePostfix(postfix);
+    if (result === null || !Number.isFinite(result)) return null;
+    return result;
+  }
+
+  _tokenizeFormula(s) {
+    const tokens = [];
+    let i = 0;
+    while (i < s.length) {
+      const ch = s[i];
+      if (/\s/.test(ch)) { i++; continue; }
+      if (ch === '+' || ch === '-' || ch === '*' || ch === '/') {
+        tokens.push({ type: 'op', value: ch });
+        i++;
+        continue;
+      }
+      if (ch === '(') { tokens.push({ type: 'lparen' }); i++; continue; }
+      if (ch === ')') { tokens.push({ type: 'rparen' }); i++; continue; }
+      if (ch === '{') {
+        const end = s.indexOf('}', i + 1);
+        if (end === -1) return null;
+        const name = s.slice(i + 1, end);
+        if (!/^[a-zA-Z_][\w]*$/.test(name)) return null;
+        tokens.push({ type: 'placeholder', name });
+        i = end + 1;
+        continue;
+      }
+      if (/[0-9.]/.test(ch)) {
+        const start = i;
+        while (i < s.length && /[0-9.]/.test(s[i])) i++;
+        const num = parseFloat(s.slice(start, i));
+        if (Number.isNaN(num)) return null;
+        tokens.push({ type: 'number', value: num });
+        continue;
+      }
+      return null;
+    }
+    return tokens;
+  }
+
+  _toPostfix(tokens) {
+    const out = [];
+    const ops = [];
+    const prec = { '+': 1, '-': 1, '*': 2, '/': 2 };
+    for (const tok of tokens) {
+      if (tok.type === 'number') {
+        out.push(tok);
+      } else if (tok.type === 'op') {
+        while (ops.length) {
+          const top = ops[ops.length - 1];
+          if (top.type === 'op' && prec[top.value] >= prec[tok.value]) {
+            out.push(ops.pop());
+          } else break;
+        }
+        ops.push(tok);
+      } else if (tok.type === 'lparen') {
+        ops.push(tok);
+      } else if (tok.type === 'rparen') {
+        let matched = false;
+        while (ops.length) {
+          const top = ops.pop();
+          if (top.type === 'lparen') { matched = true; break; }
+          out.push(top);
+        }
+        if (!matched) return null;
+      }
+    }
+    while (ops.length) {
+      const top = ops.pop();
+      if (top.type === 'lparen') return null;
+      out.push(top);
+    }
+    return out;
+  }
+
+  _evaluatePostfix(tokens) {
+    const stack = [];
+    for (const tok of tokens) {
+      if (tok.type === 'number') {
+        stack.push(tok.value);
+      } else if (tok.type === 'op') {
+        if (stack.length < 2) return null;
+        const b = stack.pop();
+        const a = stack.pop();
+        let r;
+        switch (tok.value) {
+          case '+': r = a + b; break;
+          case '-': r = a - b; break;
+          case '*': r = a * b; break;
+          case '/':
+            if (b === 0) return null;
+            r = a / b;
+            break;
+          default: return null;
+        }
+        stack.push(r);
+      }
+    }
+    return stack.length === 1 ? stack[0] : null;
   }
 
   getAggregates(rows) {

--- a/test/formula-evaluator.test.js
+++ b/test/formula-evaluator.test.js
@@ -1,0 +1,116 @@
+/**
+ * Formula evaluator foundation (slice 1 of #47).
+ *
+ * Lands a safe expression evaluator that resolves `{field}` placeholders,
+ * supports +, -, *, /, parentheses, and numeric literals, and rejects
+ * anything outside that allowlist (no eval / Function).
+ *
+ * Function library, formula bar UI, dependency tracking, and SUM/AVG
+ * cross-row references remain queued under #47.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: [{ a: 2, b: 3, c: 4 }],
+    ...extra
+  });
+}
+
+describe('evaluateFormula: basic arithmetic', () => {
+  test('addition', () => {
+    expect(makeTable().evaluateFormula('{a} + {b}', { a: 2, b: 3 })).toBe(5);
+  });
+
+  test('subtraction, multiplication, division', () => {
+    const t = makeTable();
+    expect(t.evaluateFormula('{a} - {b}', { a: 10, b: 3 })).toBe(7);
+    expect(t.evaluateFormula('{a} * {b}', { a: 4, b: 5 })).toBe(20);
+    expect(t.evaluateFormula('{a} / {b}', { a: 12, b: 4 })).toBe(3);
+  });
+
+  test('honours operator precedence', () => {
+    expect(makeTable().evaluateFormula('{a} + {b} * {c}', { a: 1, b: 2, c: 3 })).toBe(7);
+  });
+
+  test('parentheses override precedence', () => {
+    expect(makeTable().evaluateFormula('({a} + {b}) * {c}', { a: 1, b: 2, c: 3 })).toBe(9);
+  });
+
+  test('decimal literals', () => {
+    expect(makeTable().evaluateFormula('{a} * 1.5', { a: 4 })).toBe(6);
+  });
+
+  test('numeric literals without field references', () => {
+    expect(makeTable().evaluateFormula('2 + 3 * 4', {})).toBe(14);
+  });
+});
+
+describe('evaluateFormula: invalid input', () => {
+  test('missing field returns null', () => {
+    expect(makeTable().evaluateFormula('{a} + {missing}', { a: 1 })).toBeNull();
+  });
+
+  test('non-numeric field value returns null', () => {
+    expect(makeTable().evaluateFormula('{a} * 2', { a: 'hello' })).toBeNull();
+  });
+
+  test('division by zero returns null (rather than Infinity)', () => {
+    expect(makeTable().evaluateFormula('{a} / {b}', { a: 1, b: 0 })).toBeNull();
+  });
+
+  test('disallowed token returns null and warns once', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const t = makeTable();
+
+    expect(t.evaluateFormula('alert(1)', {})).toBeNull();
+    expect(t.evaluateFormula('alert(1)', {})).toBeNull();
+    const matches = warnSpy.mock.calls.filter(c => /alert\(1\)/.test(String(c[0])));
+    expect(matches).toHaveLength(1);
+
+    warnSpy.mockRestore();
+  });
+
+  test('mismatched parentheses return null', () => {
+    expect(makeTable().evaluateFormula('({a} + {b}', { a: 1, b: 2 })).toBeNull();
+    expect(makeTable().evaluateFormula('{a} + {b})', { a: 1, b: 2 })).toBeNull();
+  });
+});
+
+describe('Render integration', () => {
+  test('column with formula renders the computed value', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'qty' },
+        { field: 'price' },
+        { field: 'total', label: 'Total', formula: '{qty} * {price}' }
+      ],
+      data: [
+        { qty: 2,  price: 5  },
+        { qty: 10, price: 1.5 }
+      ]
+    });
+    table.render();
+
+    const totals = document.querySelectorAll('td[data-field="total"]');
+    expect(totals[0].textContent).toBe('10');
+    expect(totals[1].textContent).toBe('15');
+  });
+
+  test('formula evaluating to null falls back to empty cell', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'qty' },
+        { field: 'total', formula: '{qty} * {missing}' }
+      ],
+      data: [{ qty: 2 }]
+    });
+    table.render();
+
+    const total = document.querySelector('td[data-field="total"]');
+    expect(total.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #47. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR implements the evaluator + render-integration portions.

- `column.formula: string` referencing other column values via `{field}` placeholders, with arithmetic operators `+ - * /`, parentheses, and numeric literals (integers + decimals).
- `evaluateFormula(formula, row)` tokenises, resolves placeholders to numeric row values, runs shunting-yard infix → postfix, then walks postfix on a stack. **Never uses `eval` / `Function`** so consumer data cannot escape into JS execution.
- Missing or non-numeric placeholders return `null`. Division by zero returns `null` rather than `±Infinity`. Disallowed tokens (`alert(1)`, `;`, etc.) return `null` and emit a single `console.warn` per `(formula, reason)` tuple per session.
- Render integration: when `column.formula` is set, the cell shows the computed value (or empty string when the formula returns `null`). Columns without `formula` render exactly as before.

## Out of scope (still tracked on #47)
- Function library: `ROUND` / `IF` / `CONCAT` / `DATE`
- Formula bar UI for live cell entry
- Dependency tracking with topological recompute order
- `SUM({field})` / `AVG({field})` cross-row references (bridge to #48 aggregation)

## Tests
New file `test/formula-evaluator.test.js` — 13 cases:
- `+`, `-`, `*`, `/` with `{field}` placeholders
- Operator precedence (`{a} + {b} * {c}` → 7)
- Parentheses override precedence
- Decimal literals
- Pure-literal expressions (no placeholders)
- Missing field → `null`
- Non-numeric field → `null`
- Division by zero → `null`
- Disallowed token → `null` + single warn per session
- Mismatched parentheses → `null`
- Render integration: formula cell shows computed value
- Render integration: formula null → empty cell

Full suite: 74/75 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #47