### PR TITLE
feat(formulas): function library — ROUND / FLOOR / CEIL / ABS / MIN / MAX

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2743,6 +2743,8 @@ class TableCrafter {
       return null;
     }
 
+    // Resolve placeholders to numeric values up front so the parser only sees
+    // numbers, ops, parens, commas, and function names.
     const resolved = [];
     for (const tok of tokens) {
       if (tok.type === 'placeholder') {
@@ -2755,15 +2757,124 @@ class TableCrafter {
       }
     }
 
-    const postfix = this._toPostfix(resolved);
-    if (!postfix) {
-      warnOnce('mismatched parentheses');
+    const ctx = { tokens: resolved, pos: 0, error: false };
+    const result = this._parseFormulaExpression(ctx);
+    if (ctx.error || ctx.pos !== resolved.length) {
+      warnOnce(ctx.error || 'parse error');
       return null;
     }
-
-    const result = this._evaluatePostfix(postfix);
     if (result === null || !Number.isFinite(result)) return null;
     return result;
+  }
+
+  _parseFormulaExpression(ctx) {
+    let left = this._parseFormulaTerm(ctx);
+    if (left === null) return null;
+    while (!ctx.error && ctx.pos < ctx.tokens.length) {
+      const tok = ctx.tokens[ctx.pos];
+      if (tok.type === 'op' && (tok.value === '+' || tok.value === '-')) {
+        ctx.pos++;
+        const right = this._parseFormulaTerm(ctx);
+        if (right === null) return null;
+        left = tok.value === '+' ? left + right : left - right;
+      } else break;
+    }
+    return left;
+  }
+
+  _parseFormulaTerm(ctx) {
+    let left = this._parseFormulaFactor(ctx);
+    if (left === null) return null;
+    while (!ctx.error && ctx.pos < ctx.tokens.length) {
+      const tok = ctx.tokens[ctx.pos];
+      if (tok.type === 'op' && (tok.value === '*' || tok.value === '/')) {
+        ctx.pos++;
+        const right = this._parseFormulaFactor(ctx);
+        if (right === null) return null;
+        if (tok.value === '/') {
+          if (right === 0) { ctx.error = 'division by zero'; return null; }
+          left = left / right;
+        } else {
+          left = left * right;
+        }
+      } else break;
+    }
+    return left;
+  }
+
+  _parseFormulaFactor(ctx) {
+    if (ctx.pos >= ctx.tokens.length) { ctx.error = 'unexpected end of input'; return null; }
+    const tok = ctx.tokens[ctx.pos];
+
+    if (tok.type === 'number') {
+      ctx.pos++;
+      return tok.value;
+    }
+    if (tok.type === 'lparen') {
+      ctx.pos++;
+      const inner = this._parseFormulaExpression(ctx);
+      if (inner === null) return null;
+      if (ctx.tokens[ctx.pos] && ctx.tokens[ctx.pos].type === 'rparen') {
+        ctx.pos++;
+        return inner;
+      }
+      ctx.error = 'mismatched parentheses';
+      return null;
+    }
+    if (tok.type === 'function') {
+      ctx.pos++;
+      // Function must be immediately followed by '('.
+      if (!(ctx.tokens[ctx.pos] && ctx.tokens[ctx.pos].type === 'lparen')) {
+        ctx.error = `expected ( after ${tok.name}`;
+        return null;
+      }
+      ctx.pos++;
+      const args = [];
+      if (!(ctx.tokens[ctx.pos] && ctx.tokens[ctx.pos].type === 'rparen')) {
+        const first = this._parseFormulaExpression(ctx);
+        if (first === null) return null;
+        args.push(first);
+        while (ctx.tokens[ctx.pos] && ctx.tokens[ctx.pos].type === 'comma') {
+          ctx.pos++;
+          const next = this._parseFormulaExpression(ctx);
+          if (next === null) return null;
+          args.push(next);
+        }
+      }
+      if (!(ctx.tokens[ctx.pos] && ctx.tokens[ctx.pos].type === 'rparen')) {
+        ctx.error = `mismatched parentheses in ${tok.name}`;
+        return null;
+      }
+      ctx.pos++;
+      const result = this._callFormulaFunction(tok.name, args);
+      if (result === null) {
+        ctx.error = `function ${tok.name} failed`;
+        return null;
+      }
+      return result;
+    }
+    ctx.error = `unexpected token ${tok.type}`;
+    return null;
+  }
+
+  _callFormulaFunction(name, args) {
+    switch (name) {
+      case 'ROUND': {
+        if (args.length === 1) return Math.round(args[0]);
+        if (args.length === 2) {
+          const v = args[0], d = args[1];
+          // Avoid 1.005 * 100 floating-point quirks via string-based round.
+          return +(Math.round(v + 'e' + d) + 'e-' + d);
+        }
+        return null;
+      }
+      case 'FLOOR': return args.length === 1 ? Math.floor(args[0]) : null;
+      case 'CEIL':  return args.length === 1 ? Math.ceil(args[0])  : null;
+      case 'ABS':   return args.length === 1 ? Math.abs(args[0])   : null;
+      case 'MIN':   return args.length >= 1 ? Math.min(...args) : null;
+      case 'MAX':   return args.length >= 1 ? Math.max(...args) : null;
+      default:      return null;
+    }
   }
 
   _tokenizeFormula(s) {
@@ -2779,6 +2890,7 @@ class TableCrafter {
       }
       if (ch === '(') { tokens.push({ type: 'lparen' }); i++; continue; }
       if (ch === ')') { tokens.push({ type: 'rparen' }); i++; continue; }
+      if (ch === ',') { tokens.push({ type: 'comma' }); i++; continue; }
       if (ch === '{') {
         const end = s.indexOf('}', i + 1);
         if (end === -1) return null;
@@ -2796,70 +2908,15 @@ class TableCrafter {
         tokens.push({ type: 'number', value: num });
         continue;
       }
+      if (/[a-zA-Z_]/.test(ch)) {
+        const start = i;
+        while (i < s.length && /[a-zA-Z_]/.test(s[i])) i++;
+        tokens.push({ type: 'function', name: s.slice(start, i) });
+        continue;
+      }
       return null;
     }
     return tokens;
-  }
-
-  _toPostfix(tokens) {
-    const out = [];
-    const ops = [];
-    const prec = { '+': 1, '-': 1, '*': 2, '/': 2 };
-    for (const tok of tokens) {
-      if (tok.type === 'number') {
-        out.push(tok);
-      } else if (tok.type === 'op') {
-        while (ops.length) {
-          const top = ops[ops.length - 1];
-          if (top.type === 'op' && prec[top.value] >= prec[tok.value]) {
-            out.push(ops.pop());
-          } else break;
-        }
-        ops.push(tok);
-      } else if (tok.type === 'lparen') {
-        ops.push(tok);
-      } else if (tok.type === 'rparen') {
-        let matched = false;
-        while (ops.length) {
-          const top = ops.pop();
-          if (top.type === 'lparen') { matched = true; break; }
-          out.push(top);
-        }
-        if (!matched) return null;
-      }
-    }
-    while (ops.length) {
-      const top = ops.pop();
-      if (top.type === 'lparen') return null;
-      out.push(top);
-    }
-    return out;
-  }
-
-  _evaluatePostfix(tokens) {
-    const stack = [];
-    for (const tok of tokens) {
-      if (tok.type === 'number') {
-        stack.push(tok.value);
-      } else if (tok.type === 'op') {
-        if (stack.length < 2) return null;
-        const b = stack.pop();
-        const a = stack.pop();
-        let r;
-        switch (tok.value) {
-          case '+': r = a + b; break;
-          case '-': r = a - b; break;
-          case '*': r = a * b; break;
-          case '/':
-            if (b === 0) return null;
-            r = a / b;
-            break;
-          default: return null;
-        }
-        stack.push(r);
-      }
-    }
-    return stack.length === 1 ? stack[0] : null;
   }
 
   /**

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -782,9 +782,17 @@ class TableCrafter {
         const columnPromises = this.config.columns.map(async (column) => {
           const td = document.createElement('td');
 
-          // Format lookup values
-          let displayValue = row[column.field];
-          
+          // Resolve formula columns first; the computed numeric value (or
+          // null on bad formula / missing field) takes the place of the
+          // raw row value for display.
+          let displayValue;
+          if (column.formula) {
+            const computed = this.evaluateFormula(column.formula, row);
+            displayValue = computed === null ? '' : computed;
+          } else {
+            displayValue = row[column.field];
+          }
+
           if (displayValue === null || displayValue === undefined) {
              displayValue = '';
           }
@@ -2705,6 +2713,154 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Evaluate a column formula string against a row.
+   *
+   * Supported grammar: numeric literals (12, 3.5), `{field}` placeholders,
+   * `+ - * /`, and parentheses. Anything else returns null and emits a single
+   * console.warn per (formula, error) tuple per session.
+   *
+   * Missing or non-numeric field references return null. Division by zero
+   * returns null rather than +/-Infinity. The implementation tokenises and
+   * evaluates via a shunting-yard postfix walk — never via eval / Function.
+   */
+  evaluateFormula(formula, row) {
+    if (typeof formula !== 'string') return null;
+    if (!this._formulaWarned) this._formulaWarned = new Set();
+
+    const warnOnce = reason => {
+      const key = `${formula}|${reason}`;
+      if (!this._formulaWarned.has(key)) {
+        this._formulaWarned.add(key);
+        console.warn(`TableCrafter formula: ${reason} in "${formula}"`);
+      }
+    };
+
+    const tokens = this._tokenizeFormula(formula);
+    if (!tokens) {
+      warnOnce('disallowed token');
+      return null;
+    }
+
+    const resolved = [];
+    for (const tok of tokens) {
+      if (tok.type === 'placeholder') {
+        if (!row || !(tok.name in row)) return null;
+        const num = Number(row[tok.name]);
+        if (Number.isNaN(num)) return null;
+        resolved.push({ type: 'number', value: num });
+      } else {
+        resolved.push(tok);
+      }
+    }
+
+    const postfix = this._toPostfix(resolved);
+    if (!postfix) {
+      warnOnce('mismatched parentheses');
+      return null;
+    }
+
+    const result = this._evaluatePostfix(postfix);
+    if (result === null || !Number.isFinite(result)) return null;
+    return result;
+  }
+
+  _tokenizeFormula(s) {
+    const tokens = [];
+    let i = 0;
+    while (i < s.length) {
+      const ch = s[i];
+      if (/\s/.test(ch)) { i++; continue; }
+      if (ch === '+' || ch === '-' || ch === '*' || ch === '/') {
+        tokens.push({ type: 'op', value: ch });
+        i++;
+        continue;
+      }
+      if (ch === '(') { tokens.push({ type: 'lparen' }); i++; continue; }
+      if (ch === ')') { tokens.push({ type: 'rparen' }); i++; continue; }
+      if (ch === '{') {
+        const end = s.indexOf('}', i + 1);
+        if (end === -1) return null;
+        const name = s.slice(i + 1, end);
+        if (!/^[a-zA-Z_][\w]*$/.test(name)) return null;
+        tokens.push({ type: 'placeholder', name });
+        i = end + 1;
+        continue;
+      }
+      if (/[0-9.]/.test(ch)) {
+        const start = i;
+        while (i < s.length && /[0-9.]/.test(s[i])) i++;
+        const num = parseFloat(s.slice(start, i));
+        if (Number.isNaN(num)) return null;
+        tokens.push({ type: 'number', value: num });
+        continue;
+      }
+      return null;
+    }
+    return tokens;
+  }
+
+  _toPostfix(tokens) {
+    const out = [];
+    const ops = [];
+    const prec = { '+': 1, '-': 1, '*': 2, '/': 2 };
+    for (const tok of tokens) {
+      if (tok.type === 'number') {
+        out.push(tok);
+      } else if (tok.type === 'op') {
+        while (ops.length) {
+          const top = ops[ops.length - 1];
+          if (top.type === 'op' && prec[top.value] >= prec[tok.value]) {
+            out.push(ops.pop());
+          } else break;
+        }
+        ops.push(tok);
+      } else if (tok.type === 'lparen') {
+        ops.push(tok);
+      } else if (tok.type === 'rparen') {
+        let matched = false;
+        while (ops.length) {
+          const top = ops.pop();
+          if (top.type === 'lparen') { matched = true; break; }
+          out.push(top);
+        }
+        if (!matched) return null;
+      }
+    }
+    while (ops.length) {
+      const top = ops.pop();
+      if (top.type === 'lparen') return null;
+      out.push(top);
+    }
+    return out;
+  }
+
+  _evaluatePostfix(tokens) {
+    const stack = [];
+    for (const tok of tokens) {
+      if (tok.type === 'number') {
+        stack.push(tok.value);
+      } else if (tok.type === 'op') {
+        if (stack.length < 2) return null;
+        const b = stack.pop();
+        const a = stack.pop();
+        let r;
+        switch (tok.value) {
+          case '+': r = a + b; break;
+          case '-': r = a - b; break;
+          case '*': r = a * b; break;
+          case '/':
+            if (b === 0) return null;
+            r = a / b;
+            break;
+          default: return null;
+        }
+        stack.push(r);
+      }
+    }
+    return stack.length === 1 ? stack[0] : null;
+  }
 
   /**
    * Set current user context

--- a/test/formula-evaluator.test.js
+++ b/test/formula-evaluator.test.js
@@ -1,0 +1,116 @@
+/**
+ * Formula evaluator foundation (slice 1 of #47).
+ *
+ * Lands a safe expression evaluator that resolves `{field}` placeholders,
+ * supports +, -, *, /, parentheses, and numeric literals, and rejects
+ * anything outside that allowlist (no eval / Function).
+ *
+ * Function library, formula bar UI, dependency tracking, and SUM/AVG
+ * cross-row references remain queued under #47.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: [{ a: 2, b: 3, c: 4 }],
+    ...extra
+  });
+}
+
+describe('evaluateFormula: basic arithmetic', () => {
+  test('addition', () => {
+    expect(makeTable().evaluateFormula('{a} + {b}', { a: 2, b: 3 })).toBe(5);
+  });
+
+  test('subtraction, multiplication, division', () => {
+    const t = makeTable();
+    expect(t.evaluateFormula('{a} - {b}', { a: 10, b: 3 })).toBe(7);
+    expect(t.evaluateFormula('{a} * {b}', { a: 4, b: 5 })).toBe(20);
+    expect(t.evaluateFormula('{a} / {b}', { a: 12, b: 4 })).toBe(3);
+  });
+
+  test('honours operator precedence', () => {
+    expect(makeTable().evaluateFormula('{a} + {b} * {c}', { a: 1, b: 2, c: 3 })).toBe(7);
+  });
+
+  test('parentheses override precedence', () => {
+    expect(makeTable().evaluateFormula('({a} + {b}) * {c}', { a: 1, b: 2, c: 3 })).toBe(9);
+  });
+
+  test('decimal literals', () => {
+    expect(makeTable().evaluateFormula('{a} * 1.5', { a: 4 })).toBe(6);
+  });
+
+  test('numeric literals without field references', () => {
+    expect(makeTable().evaluateFormula('2 + 3 * 4', {})).toBe(14);
+  });
+});
+
+describe('evaluateFormula: invalid input', () => {
+  test('missing field returns null', () => {
+    expect(makeTable().evaluateFormula('{a} + {missing}', { a: 1 })).toBeNull();
+  });
+
+  test('non-numeric field value returns null', () => {
+    expect(makeTable().evaluateFormula('{a} * 2', { a: 'hello' })).toBeNull();
+  });
+
+  test('division by zero returns null (rather than Infinity)', () => {
+    expect(makeTable().evaluateFormula('{a} / {b}', { a: 1, b: 0 })).toBeNull();
+  });
+
+  test('disallowed token returns null and warns once', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const t = makeTable();
+
+    expect(t.evaluateFormula('alert(1)', {})).toBeNull();
+    expect(t.evaluateFormula('alert(1)', {})).toBeNull();
+    const matches = warnSpy.mock.calls.filter(c => /alert\(1\)/.test(String(c[0])));
+    expect(matches).toHaveLength(1);
+
+    warnSpy.mockRestore();
+  });
+
+  test('mismatched parentheses return null', () => {
+    expect(makeTable().evaluateFormula('({a} + {b}', { a: 1, b: 2 })).toBeNull();
+    expect(makeTable().evaluateFormula('{a} + {b})', { a: 1, b: 2 })).toBeNull();
+  });
+});
+
+describe('Render integration', () => {
+  test('column with formula renders the computed value', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'qty' },
+        { field: 'price' },
+        { field: 'total', label: 'Total', formula: '{qty} * {price}' }
+      ],
+      data: [
+        { qty: 2,  price: 5  },
+        { qty: 10, price: 1.5 }
+      ]
+    });
+    table.render();
+
+    const totals = document.querySelectorAll('td[data-field="total"]');
+    expect(totals[0].textContent).toBe('10');
+    expect(totals[1].textContent).toBe('15');
+  });
+
+  test('formula evaluating to null falls back to empty cell', () => {
+    const table = makeTable({
+      columns: [
+        { field: 'qty' },
+        { field: 'total', formula: '{qty} * {missing}' }
+      ],
+      data: [{ qty: 2 }]
+    });
+    table.render();
+
+    const total = document.querySelector('td[data-field="total"]');
+    expect(total.textContent).toBe('');
+  });
+});

--- a/test/formula-functions.test.js
+++ b/test/formula-functions.test.js
@@ -1,0 +1,89 @@
+/**
+ * Formula function library (slice 2 of #47).
+ * Stacked on PR #112 (safe expression evaluator).
+ *
+ * Adds the small numeric function set: ROUND, FLOOR, CEIL, ABS, MIN, MAX.
+ * IF / comparison operators / CONCAT / DATE remain queued for follow-ups.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: []
+  });
+}
+
+describe('Formula functions: ROUND', () => {
+  test('ROUND(value) rounds to nearest integer', () => {
+    expect(makeTable().evaluateFormula('ROUND({a})', { a: 1.4 })).toBe(1);
+    expect(makeTable().evaluateFormula('ROUND({a})', { a: 1.5 })).toBe(2);
+    expect(makeTable().evaluateFormula('ROUND({a})', { a: -1.5 })).toBe(-1);
+  });
+
+  test('ROUND(value, digits) rounds to N decimal places', () => {
+    expect(makeTable().evaluateFormula('ROUND({a}, 2)', { a: 1.005 })).toBeCloseTo(1.01);
+    expect(makeTable().evaluateFormula('ROUND({a}, 0)', { a: 3.7 })).toBe(4);
+  });
+
+  test('ROUND with arithmetic inside', () => {
+    expect(makeTable().evaluateFormula('ROUND({a} / {b}, 2)', { a: 10, b: 3 })).toBeCloseTo(3.33);
+  });
+});
+
+describe('Formula functions: FLOOR / CEIL / ABS', () => {
+  test('FLOOR truncates toward negative infinity', () => {
+    expect(makeTable().evaluateFormula('FLOOR({a})', { a: 1.9 })).toBe(1);
+    expect(makeTable().evaluateFormula('FLOOR({a})', { a: -1.1 })).toBe(-2);
+  });
+
+  test('CEIL rounds toward positive infinity', () => {
+    expect(makeTable().evaluateFormula('CEIL({a})', { a: 1.1 })).toBe(2);
+    expect(makeTable().evaluateFormula('CEIL({a})', { a: -1.9 })).toBe(-1);
+  });
+
+  test('ABS', () => {
+    expect(makeTable().evaluateFormula('ABS({a})', { a: -5 })).toBe(5);
+    expect(makeTable().evaluateFormula('ABS({a})', { a: 5 })).toBe(5);
+    expect(makeTable().evaluateFormula('ABS({a} - {b})', { a: 3, b: 10 })).toBe(7);
+  });
+});
+
+describe('Formula functions: MIN / MAX (variadic)', () => {
+  test('MIN over a small set', () => {
+    expect(makeTable().evaluateFormula('MIN({a}, {b}, {c})', { a: 5, b: 2, c: 8 })).toBe(2);
+  });
+
+  test('MAX over a small set', () => {
+    expect(makeTable().evaluateFormula('MAX({a}, {b}, {c})', { a: 5, b: 2, c: 8 })).toBe(8);
+  });
+
+  test('MIN / MAX with arithmetic args', () => {
+    expect(makeTable().evaluateFormula('MIN({a} * 2, {b})', { a: 3, b: 7 })).toBe(6);
+  });
+
+  test('single-argument MIN / MAX', () => {
+    expect(makeTable().evaluateFormula('MIN({a})', { a: 5 })).toBe(5);
+  });
+});
+
+describe('Formula functions: invalid input', () => {
+  test('unknown function returns null', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(makeTable().evaluateFormula('UNKNOWN({a})', { a: 5 })).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test('wrong arity returns null', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(makeTable().evaluateFormula('ABS()', { a: 5 })).toBeNull();
+    expect(makeTable().evaluateFormula('ROUND({a}, 2, 3)', { a: 5 })).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test('non-numeric arg returns null', () => {
+    expect(makeTable().evaluateFormula('ROUND({a})', { a: 'hello' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #112 (safe expression evaluator). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #112 merges.

**Refactor**: replaces the shunting-yard postfix walker with a recursive-descent parser. Recursive descent handles function-call arity natively (both empty `ABS()` and variadic `MIN(...)`) without the bookkeeping gymnastics shunting-yard requires for arg counting.

- `ROUND(value)` — nearest integer, half-away-from-zero per `Math.round`.
- `ROUND(value, digits)` — digits-aware rounding that sidesteps `1.005 * 100 = 100.49999...` via string-based scaling.
- `FLOOR(value)`, `CEIL(value)`, `ABS(value)` — `Math.floor` / `ceil` / `abs`.
- `MIN(a, b, ...)` / `MAX(a, b, ...)` — variadic; single-arg returns the argument unchanged.
- Wrong arity / unknown function returns `null` (the existing warn-once layer in `evaluateFormula` reports the failure).

The tokeniser now also recognises identifiers (function names) and commas. The pre-resolved (`{field}` → number) token stream feeds the parser, so the existing safety guarantees still hold — no `eval`, no `Function`, only an allowlist of operators and named functions.

## Out of scope (still tracked on #47)
- `IF` and comparison operators (`>`, `<`, `>=`, `<=`, `==`, `!=`)
- `CONCAT`, `DATE`, string functions
- `SUM({field})` / `AVG({field})` cross-row references (bridge to #48 aggregation)
- Formula bar UI for live cell entry
- Dependency tracking with topological recompute

## Tests
New file `test/formula-functions.test.js` — 13 cases:
- `ROUND` (1-arg + digits-aware + with arithmetic inside)
- `FLOOR`, `CEIL`, `ABS` on positive and negative inputs
- `MIN`, `MAX` (single-arg, multi-arg, with arithmetic)
- Unknown function → `null`
- Wrong arity → `null`
- Non-numeric arg → `null`

Combined: 26/26 formula tests green (13 evaluator + 13 functions). Full suite: 87/88 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #47