### PR TITLE
feat(formulas): comparison operators + IF function

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2768,6 +2768,26 @@ class TableCrafter {
   }
 
   _parseFormulaExpression(ctx) {
+    let left = this._parseFormulaAdditive(ctx);
+    if (left === null) return null;
+    if (ctx.error || ctx.pos >= ctx.tokens.length) return left;
+    const tok = ctx.tokens[ctx.pos];
+    if (tok.type !== 'cmp') return left;
+    ctx.pos++;
+    const right = this._parseFormulaAdditive(ctx);
+    if (right === null) return null;
+    switch (tok.value) {
+      case '>':  return left >  right ? 1 : 0;
+      case '<':  return left <  right ? 1 : 0;
+      case '>=': return left >= right ? 1 : 0;
+      case '<=': return left <= right ? 1 : 0;
+      case '==': return left === right ? 1 : 0;
+      case '!=': return left !== right ? 1 : 0;
+      default: ctx.error = `unknown cmp ${tok.value}`; return null;
+    }
+  }
+
+  _parseFormulaAdditive(ctx) {
     let left = this._parseFormulaTerm(ctx);
     if (left === null) return null;
     while (!ctx.error && ctx.pos < ctx.tokens.length) {
@@ -2873,6 +2893,7 @@ class TableCrafter {
       case 'ABS':   return args.length === 1 ? Math.abs(args[0])   : null;
       case 'MIN':   return args.length >= 1 ? Math.min(...args) : null;
       case 'MAX':   return args.length >= 1 ? Math.max(...args) : null;
+      case 'IF':    return args.length === 3 ? (args[0] ? args[1] : args[2]) : null;
       default:      return null;
     }
   }
@@ -2886,6 +2907,26 @@ class TableCrafter {
       if (ch === '+' || ch === '-' || ch === '*' || ch === '/') {
         tokens.push({ type: 'op', value: ch });
         i++;
+        continue;
+      }
+      if (ch === '>' || ch === '<') {
+        if (s[i + 1] === '=') {
+          tokens.push({ type: 'cmp', value: ch + '=' });
+          i += 2;
+        } else {
+          tokens.push({ type: 'cmp', value: ch });
+          i++;
+        }
+        continue;
+      }
+      if (ch === '=' && s[i + 1] === '=') {
+        tokens.push({ type: 'cmp', value: '==' });
+        i += 2;
+        continue;
+      }
+      if (ch === '!' && s[i + 1] === '=') {
+        tokens.push({ type: 'cmp', value: '!=' });
+        i += 2;
         continue;
       }
       if (ch === '(') { tokens.push({ type: 'lparen' }); i++; continue; }

--- a/test/formula-if.test.js
+++ b/test/formula-if.test.js
@@ -1,0 +1,82 @@
+/**
+ * Formula comparisons + IF (slice 3 of #47).
+ * Stacked on PR #113 (function library).
+ *
+ * Adds the comparison operators (>, <, >=, <=, ==, !=) and the IF(cond, then,
+ * else) function. Comparison results are numeric (1 / 0) so they compose
+ * with arithmetic. IF picks `then` when cond is truthy, `else` otherwise.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }],
+    data: []
+  });
+}
+
+const ev = (formula, row = {}) => makeTable().evaluateFormula(formula, row);
+
+describe('Formula: comparison operators', () => {
+  test('>', () => {
+    expect(ev('{a} > {b}', { a: 5, b: 3 })).toBe(1);
+    expect(ev('{a} > {b}', { a: 3, b: 5 })).toBe(0);
+    expect(ev('{a} > {b}', { a: 3, b: 3 })).toBe(0);
+  });
+
+  test('<', () => {
+    expect(ev('{a} < {b}', { a: 3, b: 5 })).toBe(1);
+    expect(ev('{a} < {b}', { a: 5, b: 3 })).toBe(0);
+  });
+
+  test('>= and <=', () => {
+    expect(ev('{a} >= {b}', { a: 3, b: 3 })).toBe(1);
+    expect(ev('{a} >= {b}', { a: 2, b: 3 })).toBe(0);
+    expect(ev('{a} <= {b}', { a: 3, b: 3 })).toBe(1);
+    expect(ev('{a} <= {b}', { a: 4, b: 3 })).toBe(0);
+  });
+
+  test('== and !=', () => {
+    expect(ev('{a} == {b}', { a: 3, b: 3 })).toBe(1);
+    expect(ev('{a} == {b}', { a: 3, b: 4 })).toBe(0);
+    expect(ev('{a} != {b}', { a: 3, b: 4 })).toBe(1);
+    expect(ev('{a} != {b}', { a: 3, b: 3 })).toBe(0);
+  });
+
+  test('comparisons compose with arithmetic via numeric result', () => {
+    // (a > b) * 100 → 100 when true, 0 when false
+    expect(ev('({a} > {b}) * 100', { a: 5, b: 3 })).toBe(100);
+    expect(ev('({a} > {b}) * 100', { a: 3, b: 5 })).toBe(0);
+  });
+});
+
+describe('Formula: IF(cond, then, else)', () => {
+  test('returns the then branch when cond is truthy', () => {
+    expect(ev('IF({a} > {b}, 1, 0)', { a: 5, b: 3 })).toBe(1);
+  });
+
+  test('returns the else branch when cond is falsy', () => {
+    expect(ev('IF({a} > {b}, 1, 0)', { a: 3, b: 5 })).toBe(0);
+  });
+
+  test('branches can be expressions, not just literals', () => {
+    expect(ev('IF({a} > {b}, {a} - {b}, {b} - {a})', { a: 8, b: 3 })).toBe(5);
+    expect(ev('IF({a} > {b}, {a} - {b}, {b} - {a})', { a: 3, b: 8 })).toBe(5);
+  });
+
+  test('nested IFs', () => {
+    // IF(a > 0, IF(a > 100, 2, 1), 0)
+    expect(ev('IF({a} > 0, IF({a} > 100, 2, 1), 0)', { a: 50  })).toBe(1);
+    expect(ev('IF({a} > 0, IF({a} > 100, 2, 1), 0)', { a: 200 })).toBe(2);
+    expect(ev('IF({a} > 0, IF({a} > 100, 2, 1), 0)', { a: -1  })).toBe(0);
+  });
+
+  test('wrong arity returns null', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(ev('IF({a}, 1)', { a: 1 })).toBeNull();
+    expect(ev('IF({a}, 1, 2, 3)', { a: 1 })).toBeNull();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #113 (function library). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #113 merges.

- Tokeniser recognises `>`, `<`, `>=`, `<=`, `==`, `!=`. Single-char and two-char forms disambiguated by lookahead.
- Parser grows a new top-level `_parseFormulaExpression` that handles one optional comparison after an additive expression. Comparisons return numeric `0` / `1` so the result composes with arithmetic — `(a > b) * 100` is 100 when true, 0 when false.
- `IF(cond, then, else)` — returns `then` when cond is truthy, `else` otherwise. Both branches are evaluated eagerly; the formula grammar only produces numbers so eager eval is safe.
- Wrong-arity `IF` returns `null` via the existing function-call error path; non-numeric branches inherit the existing null-on-NaN semantics.
- Lparen body and function-call args recurse through the new expression entry, so `(a > b)` and `IF(a > b, …)` parse correctly.

## Out of scope (still tracked on #47)
- `CONCAT`, `DATE`, `DATEDIFF`, string and boolean utilities
- `SUM({field})` / `AVG({field})` cross-row references (bridge to #48 aggregation)
- Formula bar UI for live cell entry
- Dependency tracking + topological recompute order

## Tests
New file `test/formula-if.test.js` — 10 cases:
- Each comparison op (>, <, >=, <=, ==, !=) on equal / less / greater fixtures
- Comparison result composes with arithmetic
- `IF` then-branch / else-branch
- `IF` branches can be expressions, not just literals
- Nested `IF`s
- Wrong-arity `IF` returns `null`

Combined: 36/36 formula tests green (13 evaluator + 13 functions + 10 if). Full suite: 97/98 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #47