### PR TITLE
feat(theming): config.theme + themeVariables + setTheme / getTheme

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -669,6 +669,10 @@ class TableCrafter {
       this.container.appendChild(wrapper);
     }
 
+    if (typeof this._applyTheme === 'function') {
+      this._applyTheme(wrapper);
+    }
+
     // Add global search if enabled
     if (this.config.globalSearch) {
       const searchContainer = this.renderGlobalSearch();
@@ -3412,6 +3416,35 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  _applyTheme(wrapper) {
+    if (!wrapper) return;
+    const theme = this.config && this.config.theme;
+    if (typeof theme === 'string' && theme) {
+      wrapper.setAttribute('data-tc-theme', theme);
+    } else {
+      wrapper.removeAttribute('data-tc-theme');
+    }
+
+    const vars = this.config && this.config.themeVariables;
+    if (vars && typeof vars === 'object') {
+      for (const [name, value] of Object.entries(vars)) {
+        if (typeof name === 'string' && name.startsWith('--')) {
+          wrapper.style.setProperty(name, value);
+        }
+      }
+    }
+  }
+
+  getTheme() {
+    return (this.config && this.config.theme) || 'light';
+  }
+
+  setTheme(name) {
+    if (!this.config) this.config = {};
+    this.config.theme = name;
+    this.render();
   }
 
   evaluateFormula(formula, row) {

--- a/test/theming.test.js
+++ b/test/theming.test.js
@@ -1,0 +1,85 @@
+/**
+ * Theming foundation (slice 1 of #49).
+ *
+ * Lands the JS surface: `config.theme`, `config.themeVariables`,
+ * `setTheme()`, `getTheme()`. The actual CSS definitions for
+ * --tc-bg / --tc-text / etc. and the dark / high-contrast overrides
+ * ship separately so this PR can stay small.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }],
+    data: [{ id: 1 }],
+    ...extra
+  });
+}
+
+describe('Theming: config.theme', () => {
+  test('config.theme: "dark" puts data-tc-theme="dark" on the wrapper', () => {
+    const table = makeTable({ theme: 'dark' });
+    table.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    expect(wrapper.getAttribute('data-tc-theme')).toBe('dark');
+  });
+
+  test('no theme config → no data-tc-theme attribute', () => {
+    const table = makeTable();
+    table.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    expect(wrapper.getAttribute('data-tc-theme')).toBeNull();
+  });
+
+  test('arbitrary string is honoured (custom themes are first-class)', () => {
+    const table = makeTable({ theme: 'company-blue' });
+    table.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    expect(wrapper.getAttribute('data-tc-theme')).toBe('company-blue');
+  });
+});
+
+describe('Theming: config.themeVariables', () => {
+  test('CSS custom properties land as inline style on the wrapper', () => {
+    const table = makeTable({
+      themeVariables: { '--tc-bg': '#111', '--tc-text': '#eee' }
+    });
+    table.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    expect(wrapper.style.getPropertyValue('--tc-bg').trim()).toBe('#111');
+    expect(wrapper.style.getPropertyValue('--tc-text').trim()).toBe('#eee');
+  });
+
+  test('omitted themeVariables → no inline custom properties', () => {
+    const table = makeTable();
+    table.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    expect(wrapper.style.getPropertyValue('--tc-bg')).toBe('');
+  });
+});
+
+describe('Theming: setTheme / getTheme', () => {
+  test('getTheme defaults to "light"', () => {
+    const table = makeTable();
+    expect(table.getTheme()).toBe('light');
+  });
+
+  test('getTheme returns the configured theme', () => {
+    const table = makeTable({ theme: 'dark' });
+    expect(table.getTheme()).toBe('dark');
+  });
+
+  test('setTheme swaps the attribute and triggers a re-render', () => {
+    const table = makeTable({ theme: 'light' });
+    table.render();
+    const renderSpy = jest.spyOn(table, 'render');
+
+    table.setTheme('dark');
+
+    expect(table.getTheme()).toBe('dark');
+    expect(renderSpy).toHaveBeenCalled();
+    expect(document.querySelector('.tc-wrapper').getAttribute('data-tc-theme')).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #49. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR lands the JS surface; the actual CSS for `--tc-bg` / `--tc-text` / etc. and the dark / high-contrast overrides live in a follow-up CSS-only PR.

- `config.theme`: any string or undefined. When set, the rendered wrapper carries `data-tc-theme=\"...\"` so consumer CSS can target via `.tc-wrapper[data-tc-theme=\"dark\"]`. Custom theme names are first-class — pass anything (e.g. `'company-blue'`) and consumer CSS owns the rules.
- `config.themeVariables: { [cssVar]: string }` — names that start with `--` are applied as inline custom properties on the wrapper. Mostly useful for runtime theme builders that want to override a baked-in variable without shipping a stylesheet.
- `getTheme()` returns the active theme, defaulting to `'light'` when `config.theme` is unset.
- `setTheme(name)` updates `config.theme` and re-renders so the new `data-tc-theme` lands immediately.

## Out of scope (still tracked on #49)
- Shipped `tablecrafter.css` definitions for the standard custom properties + dark / high-contrast overrides
- Material-Design / Bootstrap theme presets
- Visual theme builder UI (likely lives with #50 Visual Table Builder)
- Per-table inheritance from `<html data-tc-theme>`

## Tests
New file `test/theming.test.js` — 8 cases:
- `config.theme: 'dark'` puts `data-tc-theme=\"dark\"` on the wrapper
- No theme config → no `data-tc-theme` attribute
- Arbitrary string is honoured (custom themes are first-class)
- `themeVariables` land as inline custom properties
- Omitted `themeVariables` → no inline custom properties
- `getTheme()` defaults to `'light'`
- `getTheme()` returns the configured theme
- `setTheme(name)` swaps the attribute and triggers a re-render

Full suite: 69/70 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #49