### PR TITLE
feat(viz): inline SVG sparkline cell type (foundation for #58)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -857,6 +857,14 @@ class TableCrafter {
           if (column.pinned === 'left') td.classList.add('tc-pinned-left');
           else if (column.pinned === 'right') td.classList.add('tc-pinned-right');
 
+          if (column.cellType === 'sparkline') {
+            const svg = this.renderSparkline(row[column.field], column.sparkline);
+            if (svg) td.appendChild(svg);
+            td.dataset.field = column.field;
+            tr.appendChild(td);
+            return;
+          }
+
           let displayValue;
           if (column.formula) {
             const computed = this.evaluateFormula(column.formula, row);
@@ -3416,6 +3424,49 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  renderSparkline(values, options) {
+    if (!Array.isArray(values) || values.length === 0) return null;
+
+    const numeric = values.filter(v => typeof v === 'number' && Number.isFinite(v));
+    if (numeric.length === 0) return null;
+
+    const opts = options || {};
+    const width = typeof opts.width === 'number' ? opts.width : 80;
+    const height = typeof opts.height === 'number' ? opts.height : 24;
+    const stroke = typeof opts.stroke === 'string' ? opts.stroke : 'currentColor';
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('class', 'tc-sparkline');
+    svg.setAttribute('width', String(width));
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+
+    let min = Infinity;
+    let max = -Infinity;
+    for (const v of numeric) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+
+    const n = numeric.length;
+    const range = max - min;
+    const points = numeric.map((v, i) => {
+      const x = n === 1 ? 0 : (i / (n - 1)) * width;
+      const y = range === 0 ? height / 2 : height - ((v - min) / range) * height;
+      return `${x},${y}`;
+    }).join(' ');
+
+    const poly = document.createElementNS(ns, 'polyline');
+    poly.setAttribute('fill', 'none');
+    poly.setAttribute('stroke', stroke);
+    poly.setAttribute('stroke-width', '1');
+    poly.setAttribute('points', points);
+    svg.appendChild(poly);
+    return svg;
   }
 
   _applyTheme(wrapper) {

--- a/test/sparkline.test.js
+++ b/test/sparkline.test.js
@@ -1,0 +1,118 @@
+/**
+ * Sparkline cell type (slice 1 of #58).
+ *
+ * Lands a dependency-free SVG sparkline renderer + cell-type integration.
+ * Bar / column / heatmap cell types, hover-tooltip, and animation remain
+ * queued under #58.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, history: [1, 3, 2, 4, 5] },
+  { id: 2, history: [10, 10, 10, 10] },
+  { id: 3, history: [] },
+  { id: 4, history: null }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, ...extra });
+}
+
+describe('Sparkline: renderSparkline', () => {
+  test('returns an <svg> with a <polyline>', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3, 4]);
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.querySelector('polyline')).not.toBeNull();
+  });
+
+  test('points span the full viewport horizontally', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3, 4, 5], { width: 100, height: 20 });
+    const poly = svg.querySelector('polyline');
+    const points = poly.getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    expect(points).toHaveLength(5);
+    expect(points[0][0]).toBe(0);
+    expect(points[points.length - 1][0]).toBe(100);
+  });
+
+  test('points span the full viewport vertically (low value at bottom, high at top)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 5], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    // Low value (1) → bottom of viewport (y = height = 20)
+    // High value (5) → top of viewport (y = 0)
+    expect(points[0][1]).toBe(20);
+    expect(points[1][1]).toBe(0);
+  });
+
+  test('single-value series renders a horizontal midpoint line', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([42], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    expect(points).toHaveLength(1);
+    expect(points[0][1]).toBe(10); // midpoint of height 20
+  });
+
+  test('all-equal series renders at midpoint (no NaN)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([5, 5, 5, 5], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    for (const [, y] of points) {
+      expect(y).toBe(10);
+    }
+  });
+
+  test('honours custom width / height / stroke', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3], { width: 200, height: 50, stroke: '#f00' });
+    expect(svg.getAttribute('width')).toBe('200');
+    expect(svg.getAttribute('height')).toBe('50');
+    expect(svg.querySelector('polyline').getAttribute('stroke')).toBe('#f00');
+  });
+
+  test('non-array / empty / null returns null (caller renders empty cell)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    expect(t.renderSparkline(null)).toBeNull();
+    expect(t.renderSparkline([])).toBeNull();
+    expect(t.renderSparkline('not an array')).toBeNull();
+    expect(t.renderSparkline([NaN, 'bad', null])).toBeNull();
+  });
+});
+
+describe('Sparkline: cellType integration', () => {
+  test('column with cellType "sparkline" renders an svg in the body cell', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'history', cellType: 'sparkline' }
+      ]
+    });
+    t.render();
+
+    const cells = document.querySelectorAll('td[data-field="history"]');
+    expect(cells[0].querySelector('svg')).not.toBeNull();        // [1, 3, 2, 4, 5]
+    expect(cells[1].querySelector('svg')).not.toBeNull();        // all-equal
+    expect(cells[2].querySelector('svg')).toBeNull();            // empty array
+    expect(cells[3].querySelector('svg')).toBeNull();            // null
+  });
+
+  test('column.sparkline options reach the renderer', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'history', cellType: 'sparkline', sparkline: { width: 120, height: 32 } }
+      ]
+    });
+    t.render();
+
+    const svg = document.querySelector('td[data-field="history"] svg');
+    expect(svg.getAttribute('width')).toBe('120');
+    expect(svg.getAttribute('height')).toBe('32');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #58. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR lands a dependency-free SVG sparkline (no Chart.js / D3 — explicit non-goal).

- `column.cellType: 'sparkline'` renders the column's array value as an inline `<svg><polyline /></svg>`. Per-column sparkline options: `width` / `height` / `stroke` (defaults 80×24, `currentColor`).
- Non-array / empty / non-numeric values render an empty cell so a missing series degrades gracefully.
- `table.renderSparkline(values, options?)` is exposed publicly so consumers can reuse the renderer in custom cells / cards / overlays.
- Path math: `x = i / (n - 1) * width`, `y = height - (v - min) / range * height`. Single-value series and all-equal series collapse to a horizontal midpoint line so `range === 0` cannot produce `NaN`.

## Out of scope (still tracked on #58)
- Bar / column / heatmap cell types
- Hover-tooltip with the data values
- Animation on data change
- Chart.js / D3.js integration (explicit non-goal — dependency-free)

## Tests
New file `test/sparkline.test.js` — 9 cases:
- `<svg>` with `<polyline>` is returned
- Points span the full viewport horizontally
- Low value at bottom, high value at top
- Single-value series → horizontal midpoint line
- All-equal series → horizontal midpoint (no `NaN`)
- Custom width / height / stroke honoured
- Non-array / empty / null / all-NaN → `null`
- Render integration: `cellType: 'sparkline'` puts an `<svg>` in the body cell
- Render integration: `column.sparkline` options reach the renderer

Full suite: 70/71 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #58