### PR TITLE
feat(cell-types): badge / progress / link rich cell types

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -861,6 +861,13 @@ class TableCrafter {
           if (column.pinned === 'left') td.classList.add('tc-pinned-left');
           else if (column.pinned === 'right') td.classList.add('tc-pinned-right');
 
+          if (column.cellType === 'badge' || column.cellType === 'progress' || column.cellType === 'link') {
+            this._renderRichCell(td, column, row[column.field], row);
+            td.dataset.field = column.field;
+            tr.appendChild(td);
+            return;
+          }
+
           if (column.cellType === 'sparkline') {
             const svg = this.renderSparkline(row[column.field], column.sparkline);
             if (svg) td.appendChild(svg);
@@ -3436,6 +3443,72 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  _renderRichCell(td, column, value, row) {
+    if (value === null || value === undefined) return false;
+
+    if (column.cellType === 'badge') {
+      const badge = document.createElement('span');
+      badge.classList.add('tc-badge');
+      const rawStatus = (column.badge && typeof column.badge.statusFor === 'function')
+        ? column.badge.statusFor(value, row)
+        : String(value).toLowerCase();
+      const status = typeof rawStatus === 'string' ? rawStatus : '';
+      if (/^[a-zA-Z0-9_-]+$/.test(status)) {
+        badge.classList.add(`tc-badge-${status}`);
+      }
+      badge.textContent = String(value);
+      td.appendChild(badge);
+      return true;
+    }
+
+    if (column.cellType === 'progress') {
+      const num = Number(value);
+      if (Number.isNaN(num)) return false;
+      const max = (column.progress && typeof column.progress.max === 'number') ? column.progress.max : 100;
+      let pct = max > 0 ? (num / max) * 100 : 0;
+      if (pct < 0) pct = 0;
+      if (pct > 100) pct = 100;
+      const wrap = document.createElement('div');
+      wrap.className = 'tc-progress';
+      const fill = document.createElement('div');
+      fill.className = 'tc-progress-fill';
+      fill.style.width = `${pct}%`;
+      wrap.appendChild(fill);
+      td.appendChild(wrap);
+      return true;
+    }
+
+    if (column.cellType === 'link') {
+      const href = (column.link && typeof column.link.hrefFor === 'function')
+        ? column.link.hrefFor(value, row)
+        : String(value);
+      const labelFrom = column.link && column.link.labelFrom;
+      const label = labelFrom ? row[labelFrom] : value;
+
+      if (!this._isSafeUrl(href)) {
+        const span = document.createElement('span');
+        span.textContent = String(value);
+        td.appendChild(span);
+        return true;
+      }
+      const a = document.createElement('a');
+      a.className = 'tc-link';
+      a.setAttribute('href', String(href));
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+      a.textContent = String(label);
+      td.appendChild(a);
+      return true;
+    }
+
+    return false;
+  }
+
+  _isSafeUrl(href) {
+    if (typeof href !== 'string' || !href) return false;
+    return /^(https?:|mailto:|tel:|\/|#|\?)/i.test(href);
   }
 
   getStats() {

--- a/test/rich-cell-types.test.js
+++ b/test/rich-cell-types.test.js
@@ -1,0 +1,151 @@
+/**
+ * Rich cell types: badge / progress / link (slice 1 of #42).
+ *
+ * File-upload and rich-text-editor cell types remain queued under #42;
+ * they require multipart and contentEditable plumbing respectively.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, status: 'open',   completion: 75,   url: 'https://example.com/a',         label: 'Alpha' },
+  { id: 2, status: 'closed', completion: 100,  url: 'https://example.com/b',         label: 'Beta'  },
+  { id: 3, status: 'open',   completion: -10,  url: 'javascript:alert(1)',           label: 'Bad'   },
+  { id: 4, status: null,     completion: null, url: null,                            label: null    }
+];
+
+function makeTable(columns) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('Rich cell types: badge', () => {
+  test('renders <span class="tc-badge tc-badge-{status}">{value}</span>', () => {
+    const table = makeTable([
+      { field: 'id' },
+      { field: 'status', cellType: 'badge' }
+    ]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="status"]')[0];
+    const badge = cell.querySelector('.tc-badge');
+    expect(badge).not.toBeNull();
+    expect(badge.classList.contains('tc-badge-open')).toBe(true);
+    expect(badge.textContent).toBe('open');
+  });
+
+  test('column.badge.statusFor overrides the default', () => {
+    const table = makeTable([
+      {
+        field: 'completion',
+        cellType: 'badge',
+        badge: { statusFor: v => v >= 100 ? 'done' : 'pending' }
+      }
+    ]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="completion"]');
+    expect(cells[0].querySelector('.tc-badge').classList.contains('tc-badge-pending')).toBe(true);
+    expect(cells[1].querySelector('.tc-badge').classList.contains('tc-badge-done')).toBe(true);
+  });
+
+  test('null / undefined value renders an empty cell', () => {
+    const table = makeTable([{ field: 'status', cellType: 'badge' }]);
+    table.render();
+    const last = document.querySelectorAll('td[data-field="status"]')[3];
+    expect(last.querySelector('.tc-badge')).toBeNull();
+  });
+
+  test('value content is rendered via textContent (no innerHTML)', () => {
+    const xss = [{ status: '<img src=x onerror=alert(1)>' }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const t = new TableCrafter('#t', {
+      data: xss,
+      columns: [{ field: 'status', cellType: 'badge' }]
+    });
+    t.render();
+    const cell = document.querySelector('td[data-field="status"]');
+    expect(cell.querySelector('img')).toBeNull();
+    expect(cell.querySelector('.tc-badge').textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+});
+
+describe('Rich cell types: progress', () => {
+  test('renders wrapper + fill with inline width', () => {
+    const table = makeTable([{ field: 'completion', cellType: 'progress' }]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="completion"]')[0];
+    const wrap = cell.querySelector('.tc-progress');
+    const fill = cell.querySelector('.tc-progress-fill');
+    expect(wrap).not.toBeNull();
+    expect(fill).not.toBeNull();
+    expect(fill.style.width).toBe('75%');
+  });
+
+  test('clamps values over max to 100% and below zero to 0%', () => {
+    const table = makeTable([{ field: 'completion', cellType: 'progress' }]);
+    table.render();
+
+    const cells = document.querySelectorAll('td[data-field="completion"]');
+    expect(cells[1].querySelector('.tc-progress-fill').style.width).toBe('100%');
+    expect(cells[2].querySelector('.tc-progress-fill').style.width).toBe('0%');
+  });
+
+  test('column.progress.max scales the value', () => {
+    const data2 = [{ x: 50 }];
+    document.body.innerHTML = '<div id="t"></div>';
+    const t = new TableCrafter('#t', {
+      data: data2,
+      columns: [{ field: 'x', cellType: 'progress', progress: { max: 200 } }]
+    });
+    t.render();
+
+    const fill = document.querySelector('.tc-progress-fill');
+    expect(fill.style.width).toBe('25%'); // 50 / 200
+  });
+
+  test('null / undefined value renders an empty cell', () => {
+    const table = makeTable([{ field: 'completion', cellType: 'progress' }]);
+    table.render();
+    const last = document.querySelectorAll('td[data-field="completion"]')[3];
+    expect(last.querySelector('.tc-progress')).toBeNull();
+  });
+});
+
+describe('Rich cell types: link', () => {
+  test('renders <a> with href, target=_blank, rel=noopener noreferrer', () => {
+    const table = makeTable([{ field: 'url', cellType: 'link', link: { hrefFor: v => v, labelFrom: 'label' } }]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="url"]')[0];
+    const link = cell.querySelector('a.tc-link');
+    expect(link.getAttribute('href')).toBe('https://example.com/a');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  test('label defaults to the value when no labelFrom configured', () => {
+    const table = makeTable([{ field: 'url', cellType: 'link' }]);
+    table.render();
+
+    const link = document.querySelectorAll('td[data-field="url"]')[0].querySelector('a.tc-link');
+    expect(link.textContent).toBe('https://example.com/a');
+  });
+
+  test('disallowed scheme drops href and renders a plain <span>', () => {
+    const table = makeTable([{ field: 'url', cellType: 'link' }]);
+    table.render();
+
+    const cell = document.querySelectorAll('td[data-field="url"]')[2];
+    expect(cell.querySelector('a')).toBeNull();
+    expect(cell.querySelector('span').textContent).toBe('javascript:alert(1)');
+  });
+
+  test('null / undefined value renders an empty cell', () => {
+    const table = makeTable([{ field: 'url', cellType: 'link' }]);
+    table.render();
+    const last = document.querySelectorAll('td[data-field="url"]')[3];
+    expect(last.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #42. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR lands three common rich cell types alongside the existing text / number / date infrastructure.

- `cellType: 'badge'` — renders `<span class=\"tc-badge tc-badge-{status}\">` with an optional `column.badge.statusFor(value, row)` override. The status modifier class is only emitted when the resolved status is a clean identifier (`[a-zA-Z0-9_-]+`) so attacker-controlled values cannot inject attribute selectors or trip classList's name validation.
- `cellType: 'progress'` — renders `<div class=\"tc-progress\"><div class=\"tc-progress-fill\" style=\"width: N%\"></div></div>` with N clamped to `[0, 100]`. `column.progress.max` scales the value (default 100). Non-numeric values render an empty cell.
- `cellType: 'link'` — renders `<a class=\"tc-link\" href=\"...\" target=\"_blank\" rel=\"noopener noreferrer\">{label}</a>`. href comes from `column.link.hrefFor(value, row)` (defaults to value). Label defaults to the value or comes from `column.link.labelFrom` (a sibling field name). Hrefs are validated against an allowlist (`http`, `https`, `mailto`, `tel`, plus same-origin paths and anchor / query); disallowed schemes drop the href and render a plain `<span>`.
- All three set text via `textContent` (never `innerHTML`) so consumer data cannot inject markup.
- Empty / null values render an empty cell.

## Out of scope (still tracked on #42)
- File-upload cell type (needs multipart pipeline)
- Rich-text-editor cell type (needs `contentEditable` surface)
- Animation on value change

## Tests
New file `test/rich-cell-types.test.js` — 12 cases:
- Badge: renders span with `tc-badge` + status modifier
- Badge: `statusFor` override
- Badge: null / undefined → empty
- Badge: XSS payload rendered as text (no img tag, no DOMException)
- Progress: wrapper + fill DOM with right inline width
- Progress: clamps over-max to 100% and below-zero to 0%
- Progress: `column.progress.max` scales correctly
- Progress: null / undefined → empty
- Link: `<a>` with `target=\"_blank\"` and `rel=\"noopener noreferrer\"`
- Link: label defaults to value
- Link: `javascript:` scheme drops href, renders `<span>`
- Link: null / undefined → empty cell

Full suite: 73/74 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #42