### PR TITLE
feat(columns): programmatic column CRUD (add / remove / update / get)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3445,6 +3445,53 @@ class TableCrafter {
     return tokens;
   }
 
+  addColumn(column, options) {
+    if (!column || typeof column.field !== 'string' || !column.field) {
+      throw new Error('TableCrafter: addColumn requires a non-empty `field`');
+    }
+    if (!Array.isArray(this.config.columns)) this.config.columns = [];
+    if (this.config.columns.some(c => c.field === column.field)) {
+      throw new Error(`TableCrafter: addColumn — field "${column.field}" already exists`);
+    }
+
+    const before = options && options.before;
+    if (before) {
+      const idx = this.config.columns.findIndex(c => c.field === before);
+      if (idx !== -1) {
+        this.config.columns.splice(idx, 0, column);
+        this.render();
+        return column;
+      }
+    }
+    this.config.columns.push(column);
+    this.render();
+    return column;
+  }
+
+  removeColumn(field) {
+    if (!Array.isArray(this.config.columns)) return false;
+    const before = this.config.columns.length;
+    this.config.columns = this.config.columns.filter(c => c.field !== field);
+    const removed = this.config.columns.length < before;
+    if (removed) this.render();
+    return removed;
+  }
+
+  updateColumn(field, patch) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    if (!column) {
+      throw new Error(`TableCrafter: updateColumn — unknown field "${field}"`);
+    }
+    Object.assign(column, patch || {});
+    this.render();
+    return column;
+  }
+
+  getColumn(field) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    return column ? { ...column } : null;
+  }
+
   _renderRichCell(td, column, value, row) {
     if (value === null || value === undefined) return false;
 

--- a/test/column-crud.test.js
+++ b/test/column-crud.test.js
@@ -1,0 +1,116 @@
+/**
+ * Column CRUD foundation (slice 1 of #50).
+ *
+ * Lands the programmatic addColumn / removeColumn / updateColumn / getColumn
+ * surface. Drag-and-drop column-creation UI, schema design tools, and the
+ * template gallery remain queued under #50.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, name: 'Alice', email: 'a@x' },
+  { id: 2, name: 'Bob',   email: 'b@x' }
+];
+const columns = [
+  { field: 'id',    label: 'ID' },
+  { field: 'name',  label: 'Name' },
+  { field: 'email', label: 'Email' }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  const cfg = { data, columns, ...extra };
+  cfg.columns = (cfg.columns || []).map(c => ({ ...c }));
+  return new TableCrafter('#t', cfg);
+}
+
+function headerLabels() {
+  return Array.from(document.querySelectorAll('thead th')).map(th => th.textContent);
+}
+
+describe('addColumn', () => {
+  test('appends a new column to the end of the rendered headers', () => {
+    const table = makeTable();
+    table.render();
+    table.addColumn({ field: 'team', label: 'Team' });
+    expect(headerLabels()).toEqual(['ID', 'Name', 'Email', 'Team']);
+  });
+
+  test('options.before inserts the new column before the named one', () => {
+    const table = makeTable();
+    table.render();
+    table.addColumn({ field: 'team', label: 'Team' }, { before: 'name' });
+    expect(headerLabels()).toEqual(['ID', 'Team', 'Name', 'Email']);
+  });
+
+  test('rejects columns missing a field name', () => {
+    const table = makeTable();
+    expect(() => table.addColumn({ label: 'Nope' })).toThrow(/field/i);
+  });
+
+  test('rejects duplicate field names', () => {
+    const table = makeTable();
+    expect(() => table.addColumn({ field: 'name', label: 'Dup' })).toThrow(/duplicate|already/i);
+  });
+});
+
+describe('removeColumn', () => {
+  test('removes the column from headers and body, returns true', () => {
+    const table = makeTable();
+    table.render();
+    expect(table.removeColumn('name')).toBe(true);
+    expect(headerLabels()).toEqual(['ID', 'Email']);
+    expect(document.querySelector('td[data-field="name"]')).toBeNull();
+  });
+
+  test('returns false on miss; DOM unchanged', () => {
+    const table = makeTable();
+    table.render();
+    const before = headerLabels();
+    expect(table.removeColumn('ghost')).toBe(false);
+    expect(headerLabels()).toEqual(before);
+  });
+});
+
+describe('updateColumn', () => {
+  test('shallow-merges the patch and re-renders', () => {
+    const table = makeTable();
+    table.render();
+    expect(headerLabels()).toEqual(['ID', 'Name', 'Email']);
+
+    table.updateColumn('name', { label: 'Renamed' });
+    expect(headerLabels()).toEqual(['ID', 'Renamed', 'Email']);
+  });
+
+  test('preserves existing keys not in the patch', () => {
+    const table = makeTable({
+      columns: [{ field: 'name', label: 'Name', sortable: false, hidden: false }]
+    });
+    table.updateColumn('name', { label: 'Renamed' });
+    const col = table.getColumn('name');
+    expect(col.label).toBe('Renamed');
+    expect(col.sortable).toBe(false);
+    expect(col.hidden).toBe(false);
+  });
+
+  test('throws on unknown field', () => {
+    const table = makeTable();
+    expect(() => table.updateColumn('ghost', { label: 'X' })).toThrow(/ghost|unknown/i);
+  });
+});
+
+describe('getColumn', () => {
+  test('returns a defensive copy of the column object', () => {
+    const table = makeTable();
+    const snap = table.getColumn('name');
+    expect(snap).toEqual({ field: 'name', label: 'Name' });
+    snap.label = 'TAMPER';
+    expect(table.getColumn('name').label).toBe('Name');
+  });
+
+  test('returns null for unknown field', () => {
+    const table = makeTable();
+    expect(table.getColumn('ghost')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #50. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR lands the public column-management API that an eventual visual builder UI can drive — no UI yet.

- `addColumn(column, options?)` — appends a new column. `options.before` inserts before a named column; unknown `before` falls back to append rather than failing silently. Throws on missing `field` or duplicate `field` so misuse fails loud.
- `removeColumn(field)` — filters the column out and re-renders. Returns `true` / `false` on hit / miss.
- `updateColumn(field, patch)` — shallow-merges the patch onto the existing column object and re-renders. Throws on unknown field. Existing keys not in the patch are preserved (updating `label` does not clobber `sortable` or `hidden`).
- `getColumn(field)` — returns a defensive copy, or `null` for unknown fields.

Composes cleanly with the existing `setColumnVisibility` / `setColumnOrder` / `pinColumn` API and with downstream column-config consumers (validation rules, conditional formatting, formulas, sparkline / badge / progress / link cell types) — they all read live from `this.config.columns`.

## Out of scope (still tracked on #50)
- Drag-and-drop column-creation UI / palette
- Schema design tools (typed-field templates, default values)
- Template gallery for prebuilt table layouts
- Real-time preview of in-progress edits before commit

## Tests
New file `test/column-crud.test.js` — 11 cases:
- `addColumn` appends to the end
- `addColumn(col, { before: 'name' })` inserts at the right spot
- `addColumn` throws on missing `field`
- `addColumn` throws on duplicate `field`
- `removeColumn` returns `true` and updates DOM
- `removeColumn` returns `false` on miss; DOM unchanged
- `updateColumn` shallow-merges patch and re-renders
- `updateColumn` preserves keys not in the patch
- `updateColumn` throws on unknown field
- `getColumn` returns a defensive copy
- `getColumn` returns `null` for unknown field

Full suite: 72/73 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #50