### PR TITLE
feat(selection): cell range selection foundation

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -910,6 +910,21 @@ class TableCrafter {
             td.addEventListener('click', (e) => this.startEdit(e, actualRowIndex, column.field));
           }
 
+          if (this._selection) {
+            const sel = this._selection;
+            const allFields = (this.config.columns || []).map(c => c.field);
+            const startCol = allFields.indexOf(sel.startCol);
+            const endCol = allFields.indexOf(sel.endCol);
+            const colIdx = allFields.indexOf(column.field);
+            if (actualRowIndex >= sel.startRow && actualRowIndex <= sel.endRow
+                && colIdx >= startCol && colIdx <= endCol) {
+              td.classList.add('tc-selected');
+              if (actualRowIndex === sel.anchor.row && column.field === sel.anchor.field) {
+                td.classList.add('tc-selected-anchor');
+              }
+            }
+          }
+
           tr.appendChild(td);
         });
 
@@ -3443,6 +3458,63 @@ class TableCrafter {
       }
     }
     return tokens;
+  }
+
+  selectRange(anchor, focus) {
+    const fields = (this.config.columns || []).map(c => c.field);
+    const aIdx = fields.indexOf(anchor && anchor.field);
+    const fIdx = fields.indexOf(focus && focus.field);
+    if (aIdx === -1 || fIdx === -1) return;
+
+    const startRow = Math.min(anchor.row, focus.row);
+    const endRow = Math.max(anchor.row, focus.row);
+    const startColIdx = Math.min(aIdx, fIdx);
+    const endColIdx = Math.max(aIdx, fIdx);
+
+    this._selection = {
+      startRow,
+      endRow,
+      startCol: fields[startColIdx],
+      endCol: fields[endColIdx],
+      anchor: { row: anchor.row, field: anchor.field },
+      focus: { row: focus.row, field: focus.field }
+    };
+    this.render();
+  }
+
+  getSelection() {
+    if (!this._selection) return null;
+    return {
+      startRow: this._selection.startRow,
+      endRow: this._selection.endRow,
+      startCol: this._selection.startCol,
+      endCol: this._selection.endCol,
+      anchor: { ...this._selection.anchor },
+      focus: { ...this._selection.focus }
+    };
+  }
+
+  clearSelection() {
+    this._selection = null;
+    this.render();
+  }
+
+  copySelectionAsTSV() {
+    if (!this._selection) return '';
+    const sel = this._selection;
+    const fields = (this.config.columns || []).map(c => c.field);
+    const startColIdx = fields.indexOf(sel.startCol);
+    const endColIdx = fields.indexOf(sel.endCol);
+    if (startColIdx === -1 || endColIdx === -1) return '';
+
+    const cols = fields.slice(startColIdx, endColIdx + 1);
+    const lines = [];
+    for (let r = sel.startRow; r <= sel.endRow; r++) {
+      const row = this.data && this.data[r];
+      if (!row) continue;
+      lines.push(cols.map(f => row[f] != null ? String(row[f]) : '').join('\t'));
+    }
+    return lines.join('\n');
   }
 
   addColumn(column, options) {

--- a/test/cell-selection.test.js
+++ b/test/cell-selection.test.js
@@ -1,0 +1,110 @@
+/**
+ * Cell range selection foundation (slice 1 of #43).
+ *
+ * Lands the public state API + render decoration. Shift+click event wiring,
+ * fill handle gestures, multi-rectangle selections, and clipboard writes
+ * remain queued under #43.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, name: 'Alice', email: 'alice@x' },
+  { id: 2, name: 'Bob',   email: 'bob@x'   },
+  { id: 3, name: 'Carol', email: 'carol@x' }
+];
+const columns = [
+  { field: 'id' },
+  { field: 'name' },
+  { field: 'email' }
+];
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('selectRange / getSelection', () => {
+  test('selectRange normalises into { startRow, endRow, startCol, endCol }', () => {
+    const t = makeTable();
+    t.selectRange({ row: 0, field: 'id' }, { row: 1, field: 'name' });
+    expect(t.getSelection()).toEqual({
+      startRow: 0, endRow: 1, startCol: 'id', endCol: 'name',
+      anchor: { row: 0, field: 'id' }, focus: { row: 1, field: 'name' }
+    });
+  });
+
+  test('backwards anchor / focus normalises to min/max', () => {
+    const t = makeTable();
+    t.selectRange({ row: 2, field: 'email' }, { row: 0, field: 'id' });
+    const sel = t.getSelection();
+    expect(sel.startRow).toBe(0);
+    expect(sel.endRow).toBe(2);
+    expect(sel.startCol).toBe('id');
+    expect(sel.endCol).toBe('email');
+  });
+
+  test('getSelection returns null before any selection', () => {
+    expect(makeTable().getSelection()).toBeNull();
+  });
+
+  test('getSelection returns a defensive copy', () => {
+    const t = makeTable();
+    t.selectRange({ row: 0, field: 'id' }, { row: 1, field: 'name' });
+    const snap = t.getSelection();
+    snap.startRow = 99;
+    expect(t.getSelection().startRow).toBe(0);
+  });
+
+  test('clearSelection resets to null', () => {
+    const t = makeTable();
+    t.selectRange({ row: 0, field: 'id' }, { row: 0, field: 'id' });
+    expect(t.getSelection()).not.toBeNull();
+    t.clearSelection();
+    expect(t.getSelection()).toBeNull();
+  });
+});
+
+describe('Render decoration', () => {
+  test('cells inside the selection carry tc-selected; outside do not', () => {
+    const t = makeTable();
+    t.selectRange({ row: 0, field: 'id' }, { row: 1, field: 'name' });
+    t.render();
+
+    // Inside: id/name on rows 0-1.
+    expect(document.querySelector('tr[data-row-index="0"] td[data-field="id"]').classList.contains('tc-selected')).toBe(true);
+    expect(document.querySelector('tr[data-row-index="0"] td[data-field="name"]').classList.contains('tc-selected')).toBe(true);
+    expect(document.querySelector('tr[data-row-index="1"] td[data-field="id"]').classList.contains('tc-selected')).toBe(true);
+    expect(document.querySelector('tr[data-row-index="1"] td[data-field="name"]').classList.contains('tc-selected')).toBe(true);
+
+    // Outside: row 2 / email column.
+    expect(document.querySelector('tr[data-row-index="2"] td[data-field="id"]').classList.contains('tc-selected')).toBe(false);
+    expect(document.querySelector('tr[data-row-index="0"] td[data-field="email"]').classList.contains('tc-selected')).toBe(false);
+  });
+
+  test('anchor cell also carries tc-selected-anchor', () => {
+    const t = makeTable();
+    t.selectRange({ row: 1, field: 'name' }, { row: 2, field: 'email' });
+    t.render();
+
+    const anchor = document.querySelector('tr[data-row-index="1"] td[data-field="name"]');
+    expect(anchor.classList.contains('tc-selected')).toBe(true);
+    expect(anchor.classList.contains('tc-selected-anchor')).toBe(true);
+
+    const otherSelected = document.querySelector('tr[data-row-index="2"] td[data-field="email"]');
+    expect(otherSelected.classList.contains('tc-selected')).toBe(true);
+    expect(otherSelected.classList.contains('tc-selected-anchor')).toBe(false);
+  });
+});
+
+describe('copySelectionAsTSV', () => {
+  test('returns rows joined by \\n and columns by \\t', () => {
+    const t = makeTable();
+    t.selectRange({ row: 0, field: 'id' }, { row: 1, field: 'name' });
+    expect(t.copySelectionAsTSV()).toBe('1\tAlice\n2\tBob');
+  });
+
+  test('returns empty string when no selection', () => {
+    expect(makeTable().copySelectionAsTSV()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #43. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR lands the data + render layer; event-driven selection (Shift+click, fill handle, Ctrl+drag multi-rectangle) live in follow-up UI slices.

- `selectRange(anchor, focus)` — anchor / focus are `{ row, field }` cell coordinates. The resulting rectangle is normalised so callers don't have to pre-sort min/max. Anchor and focus are preserved on the selection record so consumer code can mark the user's primary cell separately from the rest.
- `getSelection()` returns a defensive deep copy, or `null`.
- `clearSelection()` resets to `null` and re-renders.
- `copySelectionAsTSV()` walks the rectangle and returns a TSV string (rows joined by `\n`, columns by `\t`). Cells get `this.data[row][field]` stringified; null / undefined values become empty cells in the output. Consumers wire the actual clipboard write (`navigator.clipboard.writeText`) themselves.
- Render decoration: cells inside the active rectangle get `tc-selected`; the anchor cell additionally gets `tc-selected-anchor` so consumer styling can visually distinguish the user's primary cell from the rest of the selection.

## Out of scope (still tracked on #43)
- Shift+click event wiring on rendered cells (composes with #44 keyboard nav)
- Fill handle drag-to-extend
- Multi-rectangle (Ctrl+drag) selections
- Clipboard write via `navigator.clipboard.writeText`

## Tests
New file `test/cell-selection.test.js` — 9 cases:
- `selectRange` normalises into the expected shape
- Backwards anchor / focus normalises to min/max
- `getSelection()` returns `null` initially
- `getSelection()` returns a defensive copy
- `clearSelection()` resets to `null`
- Cells inside the rectangle carry `tc-selected`; outside cells do not
- Anchor cell additionally carries `tc-selected-anchor`
- `copySelectionAsTSV()` returns the expected TSV
- `copySelectionAsTSV()` returns empty string when no selection

Full suite: 70/71 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #43