### PR TITLE
feat(perf): virtual-scroll viewport math + state toggle

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3460,6 +3460,56 @@ class TableCrafter {
     return tokens;
   }
 
+  computeVirtualWindow(args) {
+    const a = args || {};
+    const totalRows = Number.isFinite(a.totalRows) && a.totalRows > 0 ? Math.floor(a.totalRows) : 0;
+    const rowHeight = Number.isFinite(a.rowHeight) && a.rowHeight > 0 ? a.rowHeight : 40;
+    const viewportHeight = Number.isFinite(a.viewportHeight) && a.viewportHeight >= 0
+      ? a.viewportHeight
+      : 0;
+    const scrollTop = Number.isFinite(a.scrollTop) && a.scrollTop > 0 ? a.scrollTop : 0;
+    const overscan = Number.isFinite(a.overscan) && a.overscan >= 0 ? Math.floor(a.overscan) : 5;
+
+    if (totalRows === 0) {
+      return { startIndex: 0, endIndex: 0, topPadding: 0, bottomPadding: 0 };
+    }
+
+    const visibleCount = viewportHeight > 0 ? Math.ceil(viewportHeight / rowHeight) : 0;
+    const firstVisible = Math.floor(scrollTop / rowHeight);
+
+    let startIndex = firstVisible - overscan;
+    if (startIndex < 0) startIndex = 0;
+    if (startIndex > totalRows) startIndex = totalRows;
+
+    let endIndex = firstVisible + visibleCount + overscan;
+    if (endIndex > totalRows) endIndex = totalRows;
+    if (endIndex < startIndex) endIndex = startIndex;
+
+    return {
+      startIndex,
+      endIndex,
+      topPadding: startIndex * rowHeight,
+      bottomPadding: (totalRows - endIndex) * rowHeight
+    };
+  }
+
+  enableVirtualScroll(options) {
+    const opts = options || {};
+    this._virtualScroll = {
+      rowHeight: Number.isFinite(opts.rowHeight) && opts.rowHeight > 0 ? opts.rowHeight : 40,
+      viewportHeight: Number.isFinite(opts.viewportHeight) && opts.viewportHeight >= 0 ? opts.viewportHeight : 400,
+      overscan: Number.isFinite(opts.overscan) && opts.overscan >= 0 ? Math.floor(opts.overscan) : 5
+    };
+  }
+
+  disableVirtualScroll() {
+    this._virtualScroll = null;
+  }
+
+  isVirtualScrolling() {
+    return Boolean(this._virtualScroll);
+  }
+
   async bench(label, fn, options) {
     const opts = options || {};
     const runs = typeof opts.runs === 'number' ? opts.runs : 50;

--- a/test/virtual-scroll.test.js
+++ b/test/virtual-scroll.test.js
@@ -1,0 +1,130 @@
+/**
+ * Virtual scrolling foundation (slice 1 of #37).
+ *
+ * Lands the pure viewport math helper + state-toggle API. Render-loop
+ * wiring (clip rows + emit spacer rows) and scroll-listener installation
+ * remain queued under #37.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }],
+    data: Array.from({ length: 1000 }, (_, i) => ({ id: i + 1 }))
+  });
+}
+
+describe('computeVirtualWindow: top of list', () => {
+  test('scrollTop=0 starts at index 0 and covers viewport + overscan', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: 0,
+      viewportHeight: 400,
+      rowHeight: 40,
+      totalRows: 1000,
+      overscan: 5
+    });
+    expect(win.startIndex).toBe(0);
+    // 400 / 40 = 10 visible, +5 overscan after = 15 (and overscan before clamps to 0)
+    expect(win.endIndex).toBe(15);
+    expect(win.topPadding).toBe(0);
+    expect(win.bottomPadding).toBe((1000 - 15) * 40);
+  });
+});
+
+describe('computeVirtualWindow: mid scroll', () => {
+  test('scrollTop=500 with rowHeight=40 starts around index 12', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: 500,
+      viewportHeight: 400,
+      rowHeight: 40,
+      totalRows: 1000,
+      overscan: 5
+    });
+    // floor(500/40) = 12, minus overscan 5 = 7
+    expect(win.startIndex).toBe(7);
+    // visibleRows = 10, end = 12 + 10 + 5 overscan = 27
+    expect(win.endIndex).toBe(27);
+    expect(win.topPadding).toBe(7 * 40);
+    expect(win.bottomPadding).toBe((1000 - 27) * 40);
+  });
+});
+
+describe('computeVirtualWindow: clamping', () => {
+  test('overscan beyond start clamps to 0', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: 0,
+      viewportHeight: 400,
+      rowHeight: 40,
+      totalRows: 1000,
+      overscan: 100
+    });
+    expect(win.startIndex).toBe(0);
+    expect(win.topPadding).toBe(0);
+  });
+
+  test('past-end scrollTop clamps endIndex to totalRows', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: 1000000,
+      viewportHeight: 400,
+      rowHeight: 40,
+      totalRows: 1000,
+      overscan: 5
+    });
+    expect(win.endIndex).toBe(1000);
+    expect(win.bottomPadding).toBe(0);
+  });
+
+  test('negative scrollTop clamps to 0', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: -50,
+      viewportHeight: 400,
+      rowHeight: 40,
+      totalRows: 100,
+      overscan: 0
+    });
+    expect(win.startIndex).toBe(0);
+    expect(win.topPadding).toBe(0);
+  });
+
+  test('zero / non-numeric viewportHeight clamps to a safe default', () => {
+    const t = makeTable();
+    const win = t.computeVirtualWindow({
+      scrollTop: 0,
+      viewportHeight: 0,
+      rowHeight: 40,
+      totalRows: 100,
+      overscan: 0
+    });
+    expect(win.startIndex).toBe(0);
+    expect(win.endIndex).toBeGreaterThanOrEqual(0);
+    expect(win.endIndex).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('enableVirtualScroll / disableVirtualScroll / isVirtualScrolling', () => {
+  test('disabled by default', () => {
+    expect(makeTable().isVirtualScrolling()).toBe(false);
+  });
+
+  test('enable / disable round-trip', () => {
+    const t = makeTable();
+    t.enableVirtualScroll({ rowHeight: 40, viewportHeight: 400 });
+    expect(t.isVirtualScrolling()).toBe(true);
+
+    t.disableVirtualScroll();
+    expect(t.isVirtualScrolling()).toBe(false);
+  });
+
+  test('enable stores config for the eventual render integration', () => {
+    const t = makeTable();
+    t.enableVirtualScroll({ rowHeight: 40, viewportHeight: 400, overscan: 8 });
+    expect(t._virtualScroll).toEqual({ rowHeight: 40, viewportHeight: 400, overscan: 8 });
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #37. I posted full AC + a TDD plan as a comment on the issue (the body was previously a one-liner). This PR ships the pure math layer; the render-loop integration that actually clips rows + emits top/bottom spacer rows lives in a follow-up.

- `computeVirtualWindow({ scrollTop, viewportHeight, rowHeight, totalRows, overscan? })` → `{ startIndex, endIndex, topPadding, bottomPadding }`. The window is inclusive on `startIndex`, exclusive on `endIndex`. `topPadding + window height + bottomPadding` always equals `totalRows * rowHeight` so the document scroll height stays intact under virtualisation.
- Bogus inputs (negative `scrollTop`, non-numeric `viewportHeight`, `scrollTop` past the end) clamp to safe defaults rather than throw — this method runs from a scroll handler and a thrown error there is much worse than a momentarily-wrong window.
- `enableVirtualScroll({ rowHeight, viewportHeight, overscan? })` stores `_virtualScroll` config. `disableVirtualScroll()` clears it. `isVirtualScrolling()` returns the bool state. Render path is untouched in this PR — the flag is only inspected by the upcoming follow-up.

## Out of scope (still tracked on #37)
- Render-loop wiring: clip rows to the window + emit top/bottom spacer rows
- Scroll-listener installation on the wrapper (composes with #44 keyboard nav)
- Variable row heights (uniform-height assumption is enough for the first cut)
- Sticky-header integration during virtual scroll (composes with #53 pinned columns)

## Tests
New file `test/virtual-scroll.test.js` — 9 cases:
- `scrollTop=0` starts at index 0 with viewport + overscan window
- Mid-scroll computes the right index range and paddings
- Overscan beyond start clamps to 0
- Past-end `scrollTop` clamps `endIndex` to `totalRows`
- Negative `scrollTop` clamps to 0
- Zero / non-numeric `viewportHeight` clamps to a safe default
- `isVirtualScrolling()` defaults to `false`
- `enable` / `disable` round-trip
- `enable` stores config for the eventual render integration

Full suite: 70/71 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #37