### PR TITLE
feat(memory): clearCaches + getMemoryFootprint helpers

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3460,6 +3460,35 @@ class TableCrafter {
     return tokens;
   }
 
+  clearCaches() {
+    if (this.lookupCache && typeof this.lookupCache.clear === 'function') {
+      this.lookupCache.clear();
+    }
+    if (this._regexCache && typeof this._regexCache.clear === 'function') {
+      this._regexCache.clear();
+    }
+    if (this._badRegexWarned && typeof this._badRegexWarned.clear === 'function') {
+      this._badRegexWarned.clear();
+    }
+    if (this._missingI18nKeys && typeof this._missingI18nKeys.clear === 'function') {
+      this._missingI18nKeys.clear();
+    }
+    if (this._formulaWarned && typeof this._formulaWarned.clear === 'function') {
+      this._formulaWarned.clear();
+    }
+  }
+
+  getMemoryFootprint() {
+    return {
+      rows: Array.isArray(this.data) ? this.data.length : 0,
+      columns: Array.isArray(this.config && this.config.columns) ? this.config.columns.length : 0,
+      lookupCacheSize: this.lookupCache && typeof this.lookupCache.size === 'number' ? this.lookupCache.size : 0,
+      regexCacheSize: this._regexCache && typeof this._regexCache.size === 'number' ? this._regexCache.size : 0,
+      validationErrorsSize: this.validationErrors && typeof this.validationErrors.size === 'number' ? this.validationErrors.size : 0,
+      pluginsSize: Array.isArray(this._plugins) ? this._plugins.length : 0
+    };
+  }
+
   computeVirtualWindow(args) {
     const a = args || {};
     const totalRows = Number.isFinite(a.totalRows) && a.totalRows > 0 ? Math.floor(a.totalRows) : 0;

--- a/test/memory-management.test.js
+++ b/test/memory-management.test.js
@@ -1,0 +1,94 @@
+/**
+ * Memory management foundation (slice 1 of #39).
+ *
+ * Lands clearCaches() + getMemoryFootprint() helpers. LRU eviction policies,
+ * detached-node helpers, and heap-snapshot integration remain queued under
+ * #39 follow-ups.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]
+  });
+}
+
+describe('clearCaches', () => {
+  test('empties the lookup cache', () => {
+    const t = makeTable();
+    t.lookupCache.set('a', { x: 1 });
+    t.lookupCache.set('b', { x: 2 });
+    expect(t.lookupCache.size).toBe(2);
+
+    t.clearCaches();
+    expect(t.lookupCache.size).toBe(0);
+  });
+
+  test('preserves persistent state (data, columns, validationErrors, plugins)', () => {
+    const t = makeTable();
+    t.validationErrors.set('0_name', ['msg']);
+    t._plugins = [{ plugin: { name: 'p' } }];
+    const dataBefore = t.data;
+    const columnsBefore = t.config.columns;
+
+    t.clearCaches();
+
+    expect(t.data).toBe(dataBefore);
+    expect(t.config.columns).toBe(columnsBefore);
+    expect(t.validationErrors.size).toBe(1);
+    expect(t._plugins).toHaveLength(1);
+  });
+
+  test('safe on a freshly-constructed table', () => {
+    const t = makeTable();
+    expect(() => t.clearCaches()).not.toThrow();
+  });
+
+  test('clears optional internal caches when present', () => {
+    const t = makeTable();
+    t._regexCache = new Map([['a|', /a/]]);
+    t._badRegexWarned = new Set(['bad']);
+    t._missingI18nKeys = new Set(['toolbar.search']);
+    t._formulaWarned = new Set(['1+x']);
+
+    t.clearCaches();
+
+    expect(t._regexCache.size).toBe(0);
+    expect(t._badRegexWarned.size).toBe(0);
+    expect(t._missingI18nKeys.size).toBe(0);
+    expect(t._formulaWarned.size).toBe(0);
+  });
+});
+
+describe('getMemoryFootprint', () => {
+  test('reports row / column counts', () => {
+    const t = makeTable();
+    const fp = t.getMemoryFootprint();
+    expect(fp.rows).toBe(2);
+    expect(fp.columns).toBe(2);
+  });
+
+  test('reports cache sizes', () => {
+    const t = makeTable();
+    t.lookupCache.set('a', { x: 1 });
+    t.lookupCache.set('b', { x: 2 });
+    expect(t.getMemoryFootprint().lookupCacheSize).toBe(2);
+  });
+
+  test('row count tracks data mutation', () => {
+    const t = makeTable();
+    expect(t.getMemoryFootprint().rows).toBe(2);
+    t.data.push({ id: 3, name: 'Carol' });
+    expect(t.getMemoryFootprint().rows).toBe(3);
+  });
+
+  test('safe on a freshly-constructed table', () => {
+    const t = makeTable();
+    const fp = t.getMemoryFootprint();
+    expect(typeof fp.rows).toBe('number');
+    expect(typeof fp.columns).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #39. Continues the AC I posted on the issue earlier in the session.

- `clearCaches()` drops every internal runtime cache the table accrues over time:
  - `lookupCache`
  - search `_regexCache`
  - search `_badRegexWarned` set
  - i18n `_missingI18nKeys` warn set
  - formula `_formulaWarned` set
  
  Persistent state (`this.data`, `this.config`, `validationErrors`, `_plugins`) is intentionally untouched — those represent the table's working set, not opportunistic optimisations.
  
- `getMemoryFootprint()` returns a coarse snapshot:
  ```
  { rows, columns, lookupCacheSize, regexCacheSize,
    validationErrorsSize, pluginsSize }
  ```
  Counts entries, not bytes — exact-byte introspection requires `performance.measureUserAgentSpecificMemory` which is gated behind COOP/COEP and not portable across runtimes.

- Both helpers are no-throw on a freshly-constructed table; absent caches are skipped silently. No re-render is triggered — the next render naturally repopulates whatever caches it consults.

## Out of scope (still tracked on #39)
- LRU eviction policies on the lookup cache (would compose nicely with #37 virtual scrolling)
- Detached-DOM-node garbage collection helpers
- Heap-snapshot integration via `performance.measureUserAgentSpecificMemory`

## Tests
New file `test/memory-management.test.js` — 8 cases:
- `clearCaches()` empties `lookupCache`
- `clearCaches()` preserves `data` / `columns` / `validationErrors` / `_plugins`
- `clearCaches()` is safe on a freshly-constructed table
- `clearCaches()` clears optional internal caches when present
- `getMemoryFootprint()` reports row / column counts
- `getMemoryFootprint()` reports cache sizes
- Row count tracks data mutation
- `getMemoryFootprint()` is safe on a freshly-constructed table

Full suite: 69/70 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #39