### PR TITLE
feat(import): RFC-4180 CSV parser + importCSV / parseCSV

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3460,6 +3460,105 @@ class TableCrafter {
     return tokens;
   }
 
+  parseCSV(text, options) {
+    const opts = options || {};
+    const delimiter = opts.delimiter || ',';
+    const useHeader = opts.header !== false;
+
+    const normalised = String(text == null ? '' : text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    if (!normalised || !normalised.trim()) {
+      return { rows: [], errors: [] };
+    }
+
+    const rawRows = [];
+    let row = [];
+    let field = '';
+    let inQuotes = false;
+    let i = 0;
+    while (i < normalised.length) {
+      const ch = normalised[i];
+      if (inQuotes) {
+        if (ch === '"') {
+          if (normalised[i + 1] === '"') {
+            field += '"';
+            i += 2;
+            continue;
+          }
+          inQuotes = false;
+          i++;
+          continue;
+        }
+        field += ch;
+        i++;
+        continue;
+      }
+      if (ch === '"' && field === '') {
+        inQuotes = true;
+        i++;
+        continue;
+      }
+      if (ch === delimiter) {
+        row.push(field);
+        field = '';
+        i++;
+        continue;
+      }
+      if (ch === '\n') {
+        row.push(field);
+        rawRows.push(row);
+        row = [];
+        field = '';
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+    }
+    if (field !== '' || row.length > 0) {
+      row.push(field);
+      rawRows.push(row);
+    }
+
+    const errors = [];
+    if (rawRows.length === 0) return { rows: [], errors };
+
+    if (!useHeader) {
+      return { rows: rawRows, errors };
+    }
+
+    const header = rawRows[0];
+    const dataRows = rawRows.slice(1);
+    const out = [];
+    for (let r = 0; r < dataRows.length; r++) {
+      const fields = dataRows[r];
+      if (fields.length !== header.length) {
+        errors.push({
+          line: r + 2,
+          message: `expected ${header.length} fields, got ${fields.length}`
+        });
+        continue;
+      }
+      const obj = {};
+      for (let h = 0; h < header.length; h++) {
+        obj[header[h]] = fields[h];
+      }
+      out.push(obj);
+    }
+    return { rows: out, errors };
+  }
+
+  importCSV(text, options) {
+    const opts = options || {};
+    const result = this.parseCSV(text, opts);
+    if (opts.append) {
+      this.data = (Array.isArray(this.data) ? this.data : []).concat(result.rows);
+    } else {
+      this.data = result.rows;
+    }
+    if (typeof this.render === 'function') this.render();
+    return result;
+  }
+
   clearCaches() {
     if (this.lookupCache && typeof this.lookupCache.clear === 'function') {
       this.lookupCache.clear();

--- a/test/csv-import.test.js
+++ b/test/csv-import.test.js
@@ -1,0 +1,119 @@
+/**
+ * CSV import foundation (slice 1 of #60).
+ *
+ * RFC-4180-flavoured parser: quoted fields can contain commas, newlines,
+ * and embedded `""`. Excel xlsx, JSON, drag-and-drop UI, and schema-aware
+ * import remain queued.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: [{ a: 1, b: 2, c: 3 }]
+  });
+}
+
+describe('parseCSV: basic', () => {
+  test('plain comma-separated values + header → array of objects', () => {
+    const t = makeTable();
+    const { rows, errors } = t.parseCSV('a,b,c\n1,2,3\n4,5,6');
+    expect(errors).toEqual([]);
+    expect(rows).toEqual([
+      { a: '1', b: '2', c: '3' },
+      { a: '4', b: '5', c: '6' }
+    ]);
+  });
+
+  test('header: false → array of arrays', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('1,2,3\n4,5,6', { header: false });
+    expect(rows).toEqual([['1', '2', '3'], ['4', '5', '6']]);
+  });
+
+  test('custom delimiter', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a;b;c\n1;2;3', { delimiter: ';' });
+    expect(rows).toEqual([{ a: '1', b: '2', c: '3' }]);
+  });
+
+  test('TSV via tab delimiter', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a\tb\tc\n1\t2\t3', { delimiter: '\t' });
+    expect(rows).toEqual([{ a: '1', b: '2', c: '3' }]);
+  });
+});
+
+describe('parseCSV: quoted fields', () => {
+  test('embedded comma inside quoted value', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"hello, world",2');
+    expect(rows).toEqual([{ a: 'hello, world', b: '2' }]);
+  });
+
+  test('embedded newline inside quoted value', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"line1\nline2",2');
+    expect(rows).toEqual([{ a: 'line1\nline2', b: '2' }]);
+  });
+
+  test('"" inside quoted value → literal "', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"she said ""hi""",2');
+    expect(rows).toEqual([{ a: 'she said "hi"', b: '2' }]);
+  });
+
+  test('mixed quoted and unquoted fields on the same row', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b,c\n1,"with, comma",3');
+    expect(rows).toEqual([{ a: '1', b: 'with, comma', c: '3' }]);
+  });
+});
+
+describe('parseCSV: error reporting', () => {
+  test('a line with too many / too few fields surfaces in errors but does not throw', () => {
+    const t = makeTable();
+    const { rows, errors } = t.parseCSV('a,b,c\n1,2,3\n1,2\n4,5,6');
+    expect(errors).toEqual([
+      expect.objectContaining({ line: 3 })
+    ]);
+    expect(rows).toEqual([
+      { a: '1', b: '2', c: '3' },
+      { a: '4', b: '5', c: '6' }
+    ]);
+  });
+
+  test('handles \\r\\n line endings', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\r\n1,2\r\n3,4');
+    expect(rows).toEqual([
+      { a: '1', b: '2' },
+      { a: '3', b: '4' }
+    ]);
+  });
+
+  test('empty input yields rows: []', () => {
+    const t = makeTable();
+    expect(t.parseCSV('').rows).toEqual([]);
+    expect(t.parseCSV('   ').rows).toEqual([]);
+  });
+});
+
+describe('importCSV: applies to this.data', () => {
+  test('replaces this.data by default', () => {
+    const t = makeTable();
+    t.importCSV('a,b\n10,20');
+    expect(t.data).toEqual([{ a: '10', b: '20' }]);
+  });
+
+  test('append: true extends this.data', () => {
+    const t = makeTable();
+    t.importCSV('a,b,c\n9,9,9', { append: true });
+    expect(t.data).toEqual([
+      { a: 1, b: 2, c: 3 },
+      { a: '9', b: '9', c: '9' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #60. AC posted on the issue earlier in the session. This PR ships the parser + integration helpers.

- `parseCSV(text, options?)` returns `{ rows, errors }`. Rather than throwing on the first bad row, malformed lines (wrong field count) surface in `errors` so subsequent valid lines still parse — a partially-broken upload still yields useful data.
- `importCSV(text, options?)` parses then applies. Replaces `this.data` by default; `{ append: true }` extends instead. Returns the same shape as `parseCSV` so callers can inspect errors after import.
- Quoted fields support embedded commas, newlines, and `\"\"` for a literal quote (RFC 4180).
- Custom `delimiter` via options (`\\t` for TSV, `;` for European locales, etc.).
- `header: true` (default) keys rows by the first row's column names; `header: false` returns rows as arrays.
- CRLF and bare-CR line endings are normalised to `\\n`.
- Empty / whitespace-only input yields `{ rows: [], errors: [] }` rather than a single empty row.

## Out of scope (still tracked on #60)
- Excel `.xlsx` import (lazy `xlsx` peer dep)
- JSON import
- Drag-and-drop file-input UI (composes with #50 Visual Table Builder)
- Schema-aware import that bridges #41 validation rules

## Tests
New file `test/csv-import.test.js` — 13 cases:
- Plain CSV + header → array of objects
- `header: false` → array of arrays
- Custom delimiter (semicolon)
- TSV via tab delimiter
- Embedded comma inside quoted value
- Embedded newline inside quoted value
- `\"\"` inside quoted value → literal `\"`
- Mixed quoted and unquoted fields on the same row
- Wrong-arity row surfaces in `errors`, not throws
- `\\r\\n` line endings handled
- Empty / whitespace input → empty rows
- `importCSV` replaces `this.data` by default
- `importCSV({ append: true })` extends `this.data`

Full suite: 74/75 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #60