### PR TITLE
feat(import): JSON import (parseJSON / importJSON)

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2707,6 +2707,124 @@ class TableCrafter {
    */
 
   /**
+   * Parse a CSV / TSV string into rows. RFC-4180-flavoured: quoted fields
+   * may contain commas, newlines, and embedded `""` for a literal quote.
+   *
+   * Returns `{ rows, errors }` rather than throwing — a malformed line
+   * surfaces in `errors` and subsequent valid lines still parse.
+   *
+   * Options:
+   *   - delimiter (default ',')
+   *   - header (default true): first row names the columns and the rest
+   *     become objects keyed by those names. With header: false, every row
+   *     is returned as an array.
+   */
+  parseCSV(text, options) {
+    const opts = options || {};
+    const delimiter = opts.delimiter || ',';
+    const useHeader = opts.header !== false;
+
+    const normalised = String(text == null ? '' : text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    if (!normalised || !normalised.trim()) {
+      return { rows: [], errors: [] };
+    }
+
+    // First pass: tokenise into rows of raw field strings.
+    const rawRows = [];
+    let row = [];
+    let field = '';
+    let inQuotes = false;
+    let i = 0;
+    while (i < normalised.length) {
+      const ch = normalised[i];
+      if (inQuotes) {
+        if (ch === '"') {
+          if (normalised[i + 1] === '"') {
+            field += '"';
+            i += 2;
+            continue;
+          }
+          inQuotes = false;
+          i++;
+          continue;
+        }
+        field += ch;
+        i++;
+        continue;
+      }
+      if (ch === '"' && field === '') {
+        inQuotes = true;
+        i++;
+        continue;
+      }
+      if (ch === delimiter) {
+        row.push(field);
+        field = '';
+        i++;
+        continue;
+      }
+      if (ch === '\n') {
+        row.push(field);
+        rawRows.push(row);
+        row = [];
+        field = '';
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+    }
+    if (field !== '' || row.length > 0) {
+      row.push(field);
+      rawRows.push(row);
+    }
+
+    const errors = [];
+    if (rawRows.length === 0) return { rows: [], errors };
+
+    if (!useHeader) {
+      return { rows: rawRows, errors };
+    }
+
+    const header = rawRows[0];
+    const dataRows = rawRows.slice(1);
+    const out = [];
+    for (let r = 0; r < dataRows.length; r++) {
+      const fields = dataRows[r];
+      if (fields.length !== header.length) {
+        errors.push({
+          line: r + 2,
+          message: `expected ${header.length} fields, got ${fields.length}`
+        });
+        continue;
+      }
+      const obj = {};
+      for (let h = 0; h < header.length; h++) {
+        obj[header[h]] = fields[h];
+      }
+      out.push(obj);
+    }
+    return { rows: out, errors };
+  }
+
+  /**
+   * Parse + apply CSV. Replaces `this.data` by default; pass
+   * `{ append: true }` to extend instead. Returns the same shape as
+   * `parseCSV` so callers can inspect errors after import.
+   */
+  importCSV(text, options) {
+    const opts = options || {};
+    const result = this.parseCSV(text, opts);
+    if (opts.append) {
+      this.data = (Array.isArray(this.data) ? this.data : []).concat(result.rows);
+    } else {
+      this.data = result.rows;
+    }
+    if (typeof this.render === 'function') this.render();
+    return result;
+  }
+
+  /**
    * Set current user context
    */
   setCurrentUser(user) {

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2808,6 +2808,76 @@ class TableCrafter {
   }
 
   /**
+   * Parse JSON input into rows. Mirrors the parseCSV API:
+   * returns `{ rows, errors }` rather than throwing.
+   *
+   * Accepted shapes:
+   *   - top-level array of row objects: `[{...}, {...}]`
+   *   - envelope object with a `data` array: `{ data: [{...}] }`
+   *   - already-parsed JS array (skips JSON.parse)
+   *
+   * Non-object array entries are dropped with an error each so a partially
+   * malformed payload still yields the valid rows. Top-level shapes other
+   * than the two above (e.g. `{ foo: 'bar' }`) return rows: [] with one
+   * error.
+   */
+  parseJSON(input) {
+    if (input === null || input === undefined || input === '') {
+      return { rows: [], errors: [] };
+    }
+
+    let parsed;
+    if (typeof input === 'string') {
+      try {
+        parsed = JSON.parse(input);
+      } catch (e) {
+        return { rows: [], errors: [{ message: `json parse: ${e.message}` }] };
+      }
+    } else {
+      parsed = input;
+    }
+
+    let candidates;
+    if (Array.isArray(parsed)) {
+      candidates = parsed;
+    } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.data)) {
+      candidates = parsed.data;
+    } else {
+      return {
+        rows: [],
+        errors: [{ message: 'json import: expected an array or { data: [...] } envelope' }]
+      };
+    }
+
+    const rows = [];
+    const errors = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const entry = candidates[i];
+      if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        rows.push(entry);
+      } else {
+        errors.push({ index: i, message: 'json import: row is not an object' });
+      }
+    }
+    return { rows, errors };
+  }
+
+  /**
+   * Parse + apply JSON. Same options shape as importCSV.
+   */
+  importJSON(input, options) {
+    const opts = options || {};
+    const result = this.parseJSON(input);
+    if (opts.append) {
+      this.data = (Array.isArray(this.data) ? this.data : []).concat(result.rows);
+    } else {
+      this.data = result.rows;
+    }
+    if (typeof this.render === 'function') this.render();
+    return result;
+  }
+
+  /**
    * Parse + apply CSV. Replaces `this.data` by default; pass
    * `{ append: true }` to extend instead. Returns the same shape as
    * `parseCSV` so callers can inspect errors after import.

--- a/test/csv-import.test.js
+++ b/test/csv-import.test.js
@@ -1,0 +1,119 @@
+/**
+ * CSV import foundation (slice 1 of #60).
+ *
+ * RFC-4180-flavoured parser: quoted fields can contain commas, newlines,
+ * and embedded `""`. Excel xlsx, JSON, drag-and-drop UI, and schema-aware
+ * import remain queued.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: [{ a: 1, b: 2, c: 3 }]
+  });
+}
+
+describe('parseCSV: basic', () => {
+  test('plain comma-separated values + header → array of objects', () => {
+    const t = makeTable();
+    const { rows, errors } = t.parseCSV('a,b,c\n1,2,3\n4,5,6');
+    expect(errors).toEqual([]);
+    expect(rows).toEqual([
+      { a: '1', b: '2', c: '3' },
+      { a: '4', b: '5', c: '6' }
+    ]);
+  });
+
+  test('header: false → array of arrays', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('1,2,3\n4,5,6', { header: false });
+    expect(rows).toEqual([['1', '2', '3'], ['4', '5', '6']]);
+  });
+
+  test('custom delimiter', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a;b;c\n1;2;3', { delimiter: ';' });
+    expect(rows).toEqual([{ a: '1', b: '2', c: '3' }]);
+  });
+
+  test('TSV via tab delimiter', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a\tb\tc\n1\t2\t3', { delimiter: '\t' });
+    expect(rows).toEqual([{ a: '1', b: '2', c: '3' }]);
+  });
+});
+
+describe('parseCSV: quoted fields', () => {
+  test('embedded comma inside quoted value', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"hello, world",2');
+    expect(rows).toEqual([{ a: 'hello, world', b: '2' }]);
+  });
+
+  test('embedded newline inside quoted value', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"line1\nline2",2');
+    expect(rows).toEqual([{ a: 'line1\nline2', b: '2' }]);
+  });
+
+  test('"" inside quoted value → literal "', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\n"she said ""hi""",2');
+    expect(rows).toEqual([{ a: 'she said "hi"', b: '2' }]);
+  });
+
+  test('mixed quoted and unquoted fields on the same row', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b,c\n1,"with, comma",3');
+    expect(rows).toEqual([{ a: '1', b: 'with, comma', c: '3' }]);
+  });
+});
+
+describe('parseCSV: error reporting', () => {
+  test('a line with too many / too few fields surfaces in errors but does not throw', () => {
+    const t = makeTable();
+    const { rows, errors } = t.parseCSV('a,b,c\n1,2,3\n1,2\n4,5,6');
+    expect(errors).toEqual([
+      expect.objectContaining({ line: 3 })
+    ]);
+    expect(rows).toEqual([
+      { a: '1', b: '2', c: '3' },
+      { a: '4', b: '5', c: '6' }
+    ]);
+  });
+
+  test('handles \\r\\n line endings', () => {
+    const t = makeTable();
+    const { rows } = t.parseCSV('a,b\r\n1,2\r\n3,4');
+    expect(rows).toEqual([
+      { a: '1', b: '2' },
+      { a: '3', b: '4' }
+    ]);
+  });
+
+  test('empty input yields rows: []', () => {
+    const t = makeTable();
+    expect(t.parseCSV('').rows).toEqual([]);
+    expect(t.parseCSV('   ').rows).toEqual([]);
+  });
+});
+
+describe('importCSV: applies to this.data', () => {
+  test('replaces this.data by default', () => {
+    const t = makeTable();
+    t.importCSV('a,b\n10,20');
+    expect(t.data).toEqual([{ a: '10', b: '20' }]);
+  });
+
+  test('append: true extends this.data', () => {
+    const t = makeTable();
+    t.importCSV('a,b,c\n9,9,9', { append: true });
+    expect(t.data).toEqual([
+      { a: 1, b: 2, c: 3 },
+      { a: '9', b: '9', c: '9' }
+    ]);
+  });
+});

--- a/test/json-import.test.js
+++ b/test/json-import.test.js
@@ -1,0 +1,91 @@
+/**
+ * JSON import (slice 2 of #60).
+ * Stacked on PR #124 (CSV import).
+ *
+ * Mirrors the parseCSV / importCSV API surface for JSON input. Two accepted
+ * shapes: a top-level array of row objects, or a top-level object with a
+ * `data` array. Anything else surfaces in `errors` rather than throwing.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'id' }, { field: 'name' }],
+    data: [{ id: 0, name: 'Existing' }]
+  });
+}
+
+describe('parseJSON', () => {
+  test('top-level array of objects → rows', () => {
+    const t = makeTable();
+    const out = t.parseJSON('[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]');
+    expect(out.errors).toEqual([]);
+    expect(out.rows).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' }
+    ]);
+  });
+
+  test('top-level { data: [...] } envelope is unwrapped', () => {
+    const t = makeTable();
+    const out = t.parseJSON('{"data":[{"id":1}]}');
+    expect(out.rows).toEqual([{ id: 1 }]);
+  });
+
+  test('accepts a parsed object as well as a string', () => {
+    const t = makeTable();
+    const out = t.parseJSON([{ id: 1 }, { id: 2 }]);
+    expect(out.rows).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  test('non-object array entries are dropped with an error', () => {
+    const t = makeTable();
+    const out = t.parseJSON('[{"id":1}, 5, null, {"id":2}]');
+    expect(out.rows).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(out.errors).toHaveLength(2);
+  });
+
+  test('malformed JSON returns rows: [] with an error rather than throwing', () => {
+    const t = makeTable();
+    const out = t.parseJSON('{not json');
+    expect(out.rows).toEqual([]);
+    expect(out.errors).toHaveLength(1);
+    expect(out.errors[0].message).toMatch(/json/i);
+  });
+
+  test('top-level non-array, non-{data} object returns rows: [] with an error', () => {
+    const t = makeTable();
+    const out = t.parseJSON('{"foo":"bar"}');
+    expect(out.rows).toEqual([]);
+    expect(out.errors).toHaveLength(1);
+  });
+
+  test('empty input returns { rows: [], errors: [] }', () => {
+    const t = makeTable();
+    expect(t.parseJSON('').rows).toEqual([]);
+    expect(t.parseJSON(null).rows).toEqual([]);
+  });
+});
+
+describe('importJSON', () => {
+  test('replaces this.data by default', () => {
+    const t = makeTable();
+    t.importJSON('[{"id":1}]');
+    expect(t.data).toEqual([{ id: 1 }]);
+  });
+
+  test('append: true extends this.data', () => {
+    const t = makeTable();
+    t.importJSON('[{"id":7}]', { append: true });
+    expect(t.data).toEqual([{ id: 0, name: 'Existing' }, { id: 7 }]);
+  });
+
+  test('returns { rows, errors } so callers can inspect after import', () => {
+    const t = makeTable();
+    const result = t.importJSON('[{"id":1}, "bad", {"id":2}]');
+    expect(result.rows).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #124 (CSV import). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #124 merges.

Mirrors the `parseCSV` / `importCSV` API surface for JSON input.

- `parseJSON(input)` returns `{ rows, errors }`. Accepts a string (parsed via `JSON.parse`), an already-parsed JS array (skips parse), or an envelope `{ data: [...] }` object. Top-level shapes other than those return `rows: []` with one error.
- Non-object array entries are dropped with an error each so a partially malformed payload still yields the valid rows.
- Malformed JSON returns `rows: []` with a parse-error rather than throwing — callers can show the error inline alongside any successfully-parsed sibling.
- `importJSON(input, options)` parses then applies. Replaces `this.data` by default; `{ append: true }` extends instead.

## Out of scope (still tracked on #60)
- Excel `.xlsx` import (lazy `xlsx` peer dep)
- Drag-and-drop file-input UI
- Schema-aware import that bridges #41 validation rules

## Tests
New file `test/json-import.test.js` — 10 cases:
- Top-level array of objects
- `{ data: [...] }` envelope unwrapped
- Already-parsed JS array accepted
- Non-object array entries dropped with errors
- Malformed JSON → `rows: []` with parse error (no throw)
- Top-level non-array, non-`{data}` object → error
- Empty / null input → `{ rows: [], errors: [] }`
- `importJSON` replaces by default
- `importJSON({ append: true })` extends
- `importJSON` returns the same `{ rows, errors }` shape

Combined with the 13 CSV tests on PR #124: 23/23 import tests green. Full suite: 84/85 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #60