### PR TITLE
ci(release): tag-driven GitHub Release workflow with conventional-commit changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for changelog)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Resolve previous tag
+        id: prev_tag
+        run: |
+          PREV=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${GITHUB_REF_NAME}$" | head -n1 || echo "")
+          echo "previous=${PREV}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV="${{ steps.prev_tag.outputs.previous }}"
+          if [ -n "$PREV" ]; then
+            RANGE="${PREV}..${GITHUB_REF_NAME}"
+          else
+            RANGE="${GITHUB_REF_NAME}"
+          fi
+
+          {
+            echo "## ${GITHUB_REF_NAME}"
+            echo
+            for type in feat fix perf refactor docs test build ci; do
+              section=$(git log $RANGE --format='%s' | grep -E "^${type}(\(|:|!)" || true)
+              if [ -n "$section" ]; then
+                case "$type" in
+                  feat)     heading="### Features" ;;
+                  fix)      heading="### Bug fixes" ;;
+                  perf)     heading="### Performance" ;;
+                  refactor) heading="### Refactors" ;;
+                  docs)     heading="### Documentation" ;;
+                  test)     heading="### Tests" ;;
+                  build)    heading="### Build" ;;
+                  ci)       heading="### CI" ;;
+                esac
+                echo "$heading"
+                echo
+                echo "$section" | sed 's/^/- /'
+                echo
+              fi
+            done
+
+            other=$(git log $RANGE --format='%s' | grep -vE '^(feat|fix|perf|refactor|docs|test|build|ci)(\(|:|!)' || true)
+            if [ -n "$other" ]; then
+              echo "### Other changes"
+              echo
+              echo "$other" | sed 's/^/- /'
+              echo
+            fi
+          } > RELEASE_NOTES.md
+
+          {
+            echo 'notes<<NOTES_EOF'
+            cat RELEASE_NOTES.md
+            echo 'NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.notes }}
+          files: |
+            dist/**

--- a/test/release-workflow.test.js
+++ b/test/release-workflow.test.js
@@ -1,0 +1,54 @@
+/**
+ * Release workflow regression net (slice 1 of #36).
+ *
+ * The workflow itself ships in `.github/workflows/release.yml`. There is no
+ * traditional unit test for a YAML workflow — verification happens via
+ * `actionlint` locally + smoke-testing on a fork. This file exists so a
+ * future edit cannot silently delete or rename the file or break the top-
+ * level shape that downstream jobs depend on.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', '.github', 'workflows', 'release.yml');
+
+describe('release workflow file', () => {
+  let contents;
+
+  beforeAll(() => {
+    contents = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+  });
+
+  test('exists', () => {
+    expect(fs.existsSync(WORKFLOW_PATH)).toBe(true);
+  });
+
+  test('starts with name: Release', () => {
+    expect(contents).toMatch(/^name:\s*Release/m);
+  });
+
+  test('triggers on v*.*.* tag push', () => {
+    expect(contents).toMatch(/on:[\s\S]*push:[\s\S]*tags:[\s\S]*v\*\.\*\.\*/);
+  });
+
+  test('declares a `release` job', () => {
+    expect(contents).toMatch(/jobs:[\s\S]*\brelease:/);
+  });
+
+  test('runs npm test as part of the pipeline', () => {
+    expect(contents).toMatch(/npm test/);
+  });
+
+  test('runs npm run build as part of the pipeline', () => {
+    expect(contents).toMatch(/npm run build/);
+  });
+
+  test('uses softprops/action-gh-release to publish the release', () => {
+    expect(contents).toMatch(/softprops\/action-gh-release/);
+  });
+
+  test('grants contents: write permission for the release step', () => {
+    expect(contents).toMatch(/permissions:[\s\S]*contents:\s*write/);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #36. AC posted on the issue earlier in the session.

`.github/workflows/release.yml` triggers on `v*.*.*` tag push. Pipeline:
1. Checkout (full history)
2. Setup Node 20
3. `npm ci`
4. `npm test`
5. `npm run build`
6. Resolve previous tag and `git log` between it and the current ref
7. Group commits by Conventional Commit type (`feat:`, `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `build:`, `ci:`); untyped commits go into an \"Other changes\" section
8. Create GitHub Release via `softprops/action-gh-release` with `dist/**` attached

`permissions: contents: write` is granted at the workflow level so the job can create the release without an external PAT.

## Out of scope (still tracked on #36)
- `npm publish` + `NPM_TOKEN` secret wiring (separate ticket — needs the org's secret plumbing)
- Conventional-commit linting on PRs
- Auto-bump `package.json` version on merge to main
- Signed commits / signed tags

## Verification
- The new `test/release-workflow.test.js` is a tiny regression net so a future edit cannot silently delete or rename the file or break the top-level shape (`name`, `on`, `jobs`, `npm test`, `npm run build`, `permissions`, `softprops/action-gh-release` usage).
- For full verification beyond shape: run `actionlint` locally on the file and smoke-test the workflow by tagging a no-op commit on a fork.

Full suite: 69/70 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #36