### PR TITLE
build(cdn): wire main / module / unpkg / jsdelivr / exports / files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,25 @@
   "name": "tablecrafter",
   "version": "1.6.5",
   "description": "A lightweight, mobile-responsive data table library with inline editing",
-  "main": "src/tablecrafter.js",
+  "main": "dist/tablecrafter.umd.js",
+  "module": "src/tablecrafter.js",
+  "unpkg": "dist/tablecrafter.umd.min.js",
+  "jsdelivr": "dist/tablecrafter.umd.min.js",
+  "exports": {
+    ".": {
+      "import": "./src/tablecrafter.js",
+      "require": "./dist/tablecrafter.umd.js",
+      "default": "./dist/tablecrafter.umd.js"
+    },
+    "./src/*": "./src/*",
+    "./dist/*": "./dist/*"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
   "directories": {
     "example": "examples",
     "test": "test"

--- a/test/cdn-build.test.js
+++ b/test/cdn-build.test.js
@@ -1,0 +1,50 @@
+/**
+ * CDN distribution metadata regression net (slice 1 of #35).
+ *
+ * The build itself ships a UMD bundle and SRI hashes (separate ticket
+ * for the actual build script). This file pins the package.json metadata
+ * so future edits cannot silently strip the unpkg / jsdelivr / exports /
+ * files fields that CDN consumers rely on.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PKG_PATH = path.join(__dirname, '..', 'package.json');
+
+describe('package.json: CDN metadata', () => {
+  let pkg;
+  beforeAll(() => { pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8')); });
+
+  test('declares main / module / unpkg / jsdelivr', () => {
+    expect(pkg.main).toBe('dist/tablecrafter.umd.js');
+    expect(pkg.module).toBe('src/tablecrafter.js');
+    expect(pkg.unpkg).toBe('dist/tablecrafter.umd.min.js');
+    expect(pkg.jsdelivr).toBe('dist/tablecrafter.umd.min.js');
+  });
+
+  test('files allowlist limits the published tarball to dist + src + docs', () => {
+    expect(pkg.files).toEqual(expect.arrayContaining([
+      'dist',
+      'src',
+      'README.md',
+      'LICENSE'
+    ]));
+  });
+
+  test('exports map declares import + require + default entries', () => {
+    expect(pkg.exports).toBeDefined();
+    expect(pkg.exports['.']).toBeDefined();
+    expect(pkg.exports['.'].require).toBe('./dist/tablecrafter.umd.js');
+    expect(pkg.exports['.'].import).toBe('./src/tablecrafter.js');
+    expect(pkg.exports['.'].default).toBe('./dist/tablecrafter.umd.js');
+  });
+
+  test('build script is wired', () => {
+    expect(pkg.scripts && pkg.scripts.build).toBeTruthy();
+  });
+
+  test('test script remains wired and untouched', () => {
+    expect(pkg.scripts && pkg.scripts.test).toBe('jest');
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #35. AC posted on the issue earlier in the session. This PR ships only the `package.json` metadata that CDN consumers need; the actual UMD bundle output + SRI hashes from the build script land in a follow-up so this PR can stay reviewable.

- `main: dist/tablecrafter.umd.js` — fresh `require('tablecrafter')` picks up the bundled artefact in CommonJS
- `module: src/tablecrafter.js` — bundlers (webpack / rollup / vite) reach for the source for treeshaking
- `unpkg` + `jsdelivr: dist/tablecrafter.umd.min.js` — `<script src=\"https://cdn.jsdelivr.net/npm/tablecrafter\">` resolves to the minified bundle without a path suffix
- `exports` map declares `import` / `require` / `default` entries plus `./src/*` and `./dist/*` passthroughs so deep imports keep working
- `files` allowlist limits the published tarball to `dist` / `src` / `README.md` / `LICENSE` — the published package no longer ships examples / test fixtures / lockfiles

`test/cdn-build.test.js` pins this metadata so a future edit cannot silently strip the unpkg / jsdelivr / exports / files fields.

## Out of scope (still tracked on #35)
- Actual UMD bundle output + minification in `build.js`
- SRI sha256 / sha384 hash files written next to the bundle
- Multi-bundle entry points (`tablecrafter-core`, `tablecrafter-full`, etc.)
- Source maps, TypeScript declarations
- Automated jsDelivr / unpkg URL smoke-tests in CI

Full suite: 66/67 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #35