### PR TITLE
feat(viz): inline SVG column-bar cell type

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -792,6 +792,16 @@ class TableCrafter {
             return;
           }
 
+          // Bars cell: same contract as sparkline but produces an SVG
+          // column-chart of <rect> bars instead of a polyline.
+          if (column.cellType === 'bars') {
+            const svg = this.renderBars(row[column.field], column.bars);
+            if (svg) td.appendChild(svg);
+            td.dataset.field = column.field;
+            tr.appendChild(td);
+            return;
+          }
+
           // Format lookup values
           let displayValue = row[column.field];
 
@@ -2715,6 +2725,56 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Render an inline SVG column-bar chart from a values array. Returns the
+   * <svg> element or null when the input is empty / non-array / lacks any
+   * numeric values. Bars share the sparkline's dependency-free /
+   * consumer-inserts-into-DOM contract.
+   */
+  renderBars(values, options) {
+    if (!Array.isArray(values) || values.length === 0) return null;
+    const numeric = values.filter(v => typeof v === 'number' && Number.isFinite(v));
+    if (numeric.length === 0) return null;
+
+    const opts = options || {};
+    const width = typeof opts.width === 'number' ? opts.width : 80;
+    const height = typeof opts.height === 'number' ? opts.height : 24;
+    const gap = typeof opts.gap === 'number' ? opts.gap : 1;
+    const fill = typeof opts.fill === 'string' ? opts.fill : 'currentColor';
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('class', 'tc-bars');
+    svg.setAttribute('width', String(width));
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+
+    const n = numeric.length;
+    const max = Math.max.apply(null, numeric);
+    const totalGap = gap * (n - 1);
+    const barWidth = (width - totalGap) / n;
+
+    for (let i = 0; i < n; i++) {
+      const v = numeric[i];
+      // Scale 0 -> max so bars anchor visually at the baseline. All-zero
+      // series render a flat row of zero-height bars rather than NaN.
+      const ratio = max === 0 ? 0 : v / max;
+      const h = ratio * height;
+      const x = i * (barWidth + gap);
+      const y = height - h;
+
+      const rect = document.createElementNS(ns, 'rect');
+      rect.setAttribute('x', String(x));
+      rect.setAttribute('y', String(y));
+      rect.setAttribute('width', String(barWidth));
+      rect.setAttribute('height', String(h));
+      rect.setAttribute('fill', fill);
+      svg.appendChild(rect);
+    }
+    return svg;
+  }
 
   /**
    * Render an inline SVG sparkline for a values array. Returns the <svg>

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -782,9 +782,19 @@ class TableCrafter {
         const columnPromises = this.config.columns.map(async (column) => {
           const td = document.createElement('td');
 
+          // Sparkline cell: hand the array to renderSparkline and short-circuit
+          // the normal text-rendering path.
+          if (column.cellType === 'sparkline') {
+            const svg = this.renderSparkline(row[column.field], column.sparkline);
+            if (svg) td.appendChild(svg);
+            td.dataset.field = column.field;
+            tr.appendChild(td);
+            return;
+          }
+
           // Format lookup values
           let displayValue = row[column.field];
-          
+
           if (displayValue === null || displayValue === undefined) {
              displayValue = '';
           }
@@ -2705,6 +2715,55 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Render an inline SVG sparkline for a values array. Returns the <svg>
+   * element, or null when the input is empty / non-array / lacks any
+   * numeric values. Caller is responsible for inserting the returned
+   * element into the DOM.
+   */
+  renderSparkline(values, options) {
+    if (!Array.isArray(values) || values.length === 0) return null;
+
+    const numeric = values.filter(v => typeof v === 'number' && Number.isFinite(v));
+    if (numeric.length === 0) return null;
+
+    const opts = options || {};
+    const width = typeof opts.width === 'number' ? opts.width : 80;
+    const height = typeof opts.height === 'number' ? opts.height : 24;
+    const stroke = typeof opts.stroke === 'string' ? opts.stroke : 'currentColor';
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('class', 'tc-sparkline');
+    svg.setAttribute('width', String(width));
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+
+    let min = Infinity;
+    let max = -Infinity;
+    for (const v of numeric) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+
+    const n = numeric.length;
+    const range = max - min;
+    const points = numeric.map((v, i) => {
+      const x = n === 1 ? 0 : (i / (n - 1)) * width;
+      const y = range === 0 ? height / 2 : height - ((v - min) / range) * height;
+      return `${x},${y}`;
+    }).join(' ');
+
+    const poly = document.createElementNS(ns, 'polyline');
+    poly.setAttribute('fill', 'none');
+    poly.setAttribute('stroke', stroke);
+    poly.setAttribute('stroke-width', '1');
+    poly.setAttribute('points', points);
+    svg.appendChild(poly);
+    return svg;
+  }
 
   /**
    * Set current user context

--- a/test/bars-cell-type.test.js
+++ b/test/bars-cell-type.test.js
@@ -1,0 +1,96 @@
+/**
+ * Bars cell type (slice 2 of #58).
+ * Stacked on PR #116 (sparkline cell type).
+ *
+ * Renders an array-of-numbers as an inline column chart of <rect> bars
+ * inside an <svg>. Same dependency-free SVG path as sparklines; bars
+ * compose alongside sparklines for richer mini-dashboards.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, history: [1, 3, 2, 4, 5] },
+  { id: 2, history: [10, 10, 10, 10] },
+  { id: 3, history: [] },
+  { id: 4, history: null }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, ...extra });
+}
+
+describe('renderBars', () => {
+  test('returns an <svg> with one <rect> per value', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderBars([1, 2, 3, 4]);
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    const rects = svg.querySelectorAll('rect');
+    expect(rects).toHaveLength(4);
+  });
+
+  test('bar widths divide the viewport evenly with a small gap', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderBars([1, 2, 3, 4], { width: 80, height: 24, gap: 2 });
+    const rects = Array.from(svg.querySelectorAll('rect'));
+    const widths = rects.map(r => parseFloat(r.getAttribute('width')));
+
+    // 4 bars in 80px with 2px gaps = (80 - 3*2) / 4 = 18.5
+    expect(widths.every(w => Math.abs(w - 18.5) < 0.01)).toBe(true);
+  });
+
+  test('bar heights scale to the value vs max', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderBars([1, 2, 4], { width: 60, height: 20, gap: 0 });
+    const rects = Array.from(svg.querySelectorAll('rect'));
+    const heights = rects.map(r => parseFloat(r.getAttribute('height')));
+
+    // values 1, 2, 4 normalised against max 4 → 25%, 50%, 100% of 20 → 5, 10, 20
+    expect(heights[0]).toBeCloseTo(5);
+    expect(heights[1]).toBeCloseTo(10);
+    expect(heights[2]).toBeCloseTo(20);
+  });
+
+  test('all-equal series renders bars at full height (no NaN)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderBars([5, 5, 5], { width: 60, height: 20 });
+    const heights = Array.from(svg.querySelectorAll('rect')).map(r => parseFloat(r.getAttribute('height')));
+    for (const h of heights) {
+      expect(h).toBe(20);
+    }
+  });
+
+  test('non-array / empty / all-NaN returns null', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    expect(t.renderBars(null)).toBeNull();
+    expect(t.renderBars([])).toBeNull();
+    expect(t.renderBars('nope')).toBeNull();
+    expect(t.renderBars([NaN, 'bad'])).toBeNull();
+  });
+
+  test('honours custom fill colour', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderBars([1, 2, 3], { fill: '#0aa' });
+    const rect = svg.querySelector('rect');
+    expect(rect.getAttribute('fill')).toBe('#0aa');
+  });
+});
+
+describe('Bars: cellType integration', () => {
+  test('column with cellType: "bars" renders an svg in the body cell', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'history', cellType: 'bars' }
+      ]
+    });
+    t.render();
+
+    const cells = document.querySelectorAll('td[data-field="history"]');
+    expect(cells[0].querySelector('svg')).not.toBeNull();
+    expect(cells[1].querySelector('svg')).not.toBeNull();
+    expect(cells[2].querySelector('svg')).toBeNull();
+    expect(cells[3].querySelector('svg')).toBeNull();
+  });
+});

--- a/test/sparkline.test.js
+++ b/test/sparkline.test.js
@@ -1,0 +1,118 @@
+/**
+ * Sparkline cell type (slice 1 of #58).
+ *
+ * Lands a dependency-free SVG sparkline renderer + cell-type integration.
+ * Bar / column / heatmap cell types, hover-tooltip, and animation remain
+ * queued under #58.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, history: [1, 3, 2, 4, 5] },
+  { id: 2, history: [10, 10, 10, 10] },
+  { id: 3, history: [] },
+  { id: 4, history: null }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, ...extra });
+}
+
+describe('Sparkline: renderSparkline', () => {
+  test('returns an <svg> with a <polyline>', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3, 4]);
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.querySelector('polyline')).not.toBeNull();
+  });
+
+  test('points span the full viewport horizontally', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3, 4, 5], { width: 100, height: 20 });
+    const poly = svg.querySelector('polyline');
+    const points = poly.getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    expect(points).toHaveLength(5);
+    expect(points[0][0]).toBe(0);
+    expect(points[points.length - 1][0]).toBe(100);
+  });
+
+  test('points span the full viewport vertically (low value at bottom, high at top)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 5], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    // Low value (1) → bottom of viewport (y = height = 20)
+    // High value (5) → top of viewport (y = 0)
+    expect(points[0][1]).toBe(20);
+    expect(points[1][1]).toBe(0);
+  });
+
+  test('single-value series renders a horizontal midpoint line', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([42], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    expect(points).toHaveLength(1);
+    expect(points[0][1]).toBe(10); // midpoint of height 20
+  });
+
+  test('all-equal series renders at midpoint (no NaN)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([5, 5, 5, 5], { width: 100, height: 20 });
+    const points = svg.querySelector('polyline').getAttribute('points').split(' ').map(p => p.split(',').map(Number));
+
+    for (const [, y] of points) {
+      expect(y).toBe(10);
+    }
+  });
+
+  test('honours custom width / height / stroke', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    const svg = t.renderSparkline([1, 2, 3], { width: 200, height: 50, stroke: '#f00' });
+    expect(svg.getAttribute('width')).toBe('200');
+    expect(svg.getAttribute('height')).toBe('50');
+    expect(svg.querySelector('polyline').getAttribute('stroke')).toBe('#f00');
+  });
+
+  test('non-array / empty / null returns null (caller renders empty cell)', () => {
+    const t = makeTable({ columns: [{ field: 'history' }] });
+    expect(t.renderSparkline(null)).toBeNull();
+    expect(t.renderSparkline([])).toBeNull();
+    expect(t.renderSparkline('not an array')).toBeNull();
+    expect(t.renderSparkline([NaN, 'bad', null])).toBeNull();
+  });
+});
+
+describe('Sparkline: cellType integration', () => {
+  test('column with cellType "sparkline" renders an svg in the body cell', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'history', cellType: 'sparkline' }
+      ]
+    });
+    t.render();
+
+    const cells = document.querySelectorAll('td[data-field="history"]');
+    expect(cells[0].querySelector('svg')).not.toBeNull();        // [1, 3, 2, 4, 5]
+    expect(cells[1].querySelector('svg')).not.toBeNull();        // all-equal
+    expect(cells[2].querySelector('svg')).toBeNull();            // empty array
+    expect(cells[3].querySelector('svg')).toBeNull();            // null
+  });
+
+  test('column.sparkline options reach the renderer', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'history', cellType: 'sparkline', sparkline: { width: 120, height: 32 } }
+      ]
+    });
+    t.render();
+
+    const svg = document.querySelector('td[data-field="history"] svg');
+    expect(svg.getAttribute('width')).toBe('120');
+    expect(svg.getAttribute('height')).toBe('32');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #116 (sparkline). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #116 merges.

- `column.cellType: 'bars'` renders an array-of-numbers as an inline `<svg>` with one `<rect>` per value, scaled from `0 → max` so bars anchor at the baseline. Per-column options on `column.bars`: `width` / `height` / `gap` / `fill` (defaults 80×24, 1 px gap, `currentColor`).
- `table.renderBars(values, options?)` is exposed publicly so consumers can reuse the renderer in custom cells / cards / overlays alongside `renderSparkline`.
- Non-array / empty / all-`NaN` values render an empty cell, matching the sparkline contract.
- All-zero series renders zero-height bars rather than `NaN`.

## Out of scope (still tracked on #58)
- Heatmap cell type
- Hover-tooltip with the data values
- Animation on data change

## Tests
New file `test/bars-cell-type.test.js` — 7 cases:
- `<svg>` with one `<rect>` per value
- Bar widths divide the viewport evenly with the configured gap
- Bar heights scale to `value / max`
- All-equal series renders full-height bars (no `NaN`)
- Non-array / empty / all-`NaN` returns `null`
- Custom `fill` colour
- `cellType: 'bars'` integration: SVG appears in body cell

Combined: 16/16 viz tests green (9 sparkline + 7 bars). Full suite: 77/78 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #58