### PR TITLE
feat(viz): inline SVG heatmap cell type

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -802,6 +802,15 @@ class TableCrafter {
             return;
           }
 
+          // Heatmap cell: same contract; intensity-coloured cell strip.
+          if (column.cellType === 'heatmap') {
+            const svg = this.renderHeatmap(row[column.field], column.heatmap);
+            if (svg) td.appendChild(svg);
+            td.dataset.field = column.field;
+            tr.appendChild(td);
+            return;
+          }
+
           // Format lookup values
           let displayValue = row[column.field];
 
@@ -2725,6 +2734,71 @@ class TableCrafter {
   /**
    * Permission System
    */
+
+  /**
+   * Render an inline SVG heatmap from a values array. Returns the <svg>
+   * element or null when the input is empty / non-array / lacks any
+   * numeric values. Each value lands as one rect; the fill colour is
+   * interpolated between minColor and maxColor based on the value's
+   * position in [min, max].
+   */
+  renderHeatmap(values, options) {
+    if (!Array.isArray(values) || values.length === 0) return null;
+    const numeric = values.filter(v => typeof v === 'number' && Number.isFinite(v));
+    if (numeric.length === 0) return null;
+
+    const opts = options || {};
+    const width = typeof opts.width === 'number' ? opts.width : 80;
+    const height = typeof opts.height === 'number' ? opts.height : 16;
+    const minColor = this._parseHexRgb(opts.minColor || '#ffffff') || { r: 255, g: 255, b: 255 };
+    const maxColor = this._parseHexRgb(opts.maxColor || '#000000') || { r: 0, g: 0, b: 0 };
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('class', 'tc-heatmap');
+    svg.setAttribute('width', String(width));
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+
+    const n = numeric.length;
+    const cellWidth = width / n;
+    const min = Math.min.apply(null, numeric);
+    const max = Math.max.apply(null, numeric);
+    const range = max - min;
+
+    for (let i = 0; i < n; i++) {
+      const v = numeric[i];
+      // All-equal series renders maxColor — `1` ratio is a sensible default
+      // because consumers expect the heatmap to read as "saturated" rather
+      // than "blank" when every reading is the same.
+      const t = range === 0 ? 1 : (v - min) / range;
+      const r = Math.round(minColor.r + (maxColor.r - minColor.r) * t);
+      const g = Math.round(minColor.g + (maxColor.g - minColor.g) * t);
+      const b = Math.round(minColor.b + (maxColor.b - minColor.b) * t);
+
+      const rect = document.createElementNS(ns, 'rect');
+      rect.setAttribute('x', String(i * cellWidth));
+      rect.setAttribute('y', '0');
+      rect.setAttribute('width', String(cellWidth));
+      rect.setAttribute('height', String(height));
+      rect.setAttribute('fill', `rgb(${r}, ${g}, ${b})`);
+      svg.appendChild(rect);
+    }
+    return svg;
+  }
+
+  _parseHexRgb(hex) {
+    if (typeof hex !== 'string') return null;
+    let s = hex.trim().replace(/^#/, '');
+    if (s.length === 3) s = s.split('').map(c => c + c).join('');
+    if (s.length !== 6 || !/^[0-9a-f]{6}$/i.test(s)) return null;
+    return {
+      r: parseInt(s.slice(0, 2), 16),
+      g: parseInt(s.slice(2, 4), 16),
+      b: parseInt(s.slice(4, 6), 16)
+    };
+  }
 
   /**
    * Render an inline SVG column-bar chart from a values array. Returns the

--- a/test/heatmap-cell-type.test.js
+++ b/test/heatmap-cell-type.test.js
@@ -1,0 +1,103 @@
+/**
+ * Heatmap cell type (slice 3 of #58).
+ * Stacked on PR #128 (bars cell type).
+ *
+ * Renders an array-of-numbers as an inline grid of fixed-size <rect>s
+ * coloured by intensity (low → minColor, high → maxColor). Hover
+ * tooltip and animation remain queued under #58.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, signal: [0.1, 0.5, 0.9, 0.2] },
+  { id: 2, signal: [1, 1, 1, 1] },
+  { id: 3, signal: [] },
+  { id: 4, signal: null }
+];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, ...extra });
+}
+
+describe('renderHeatmap', () => {
+  test('returns an <svg> with one <rect> per value', () => {
+    const t = makeTable({ columns: [{ field: 'signal' }] });
+    const svg = t.renderHeatmap([0.1, 0.5, 0.9]);
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.querySelectorAll('rect')).toHaveLength(3);
+  });
+
+  test('cells span the viewport horizontally with no overlap', () => {
+    const t = makeTable({ columns: [{ field: 'signal' }] });
+    const svg = t.renderHeatmap([0.1, 0.5, 0.9, 0.2], { width: 80, height: 16 });
+    const rects = Array.from(svg.querySelectorAll('rect'));
+    expect(rects).toHaveLength(4);
+
+    const widths = rects.map(r => parseFloat(r.getAttribute('width')));
+    const xs = rects.map(r => parseFloat(r.getAttribute('x')));
+    expect(widths.every(w => Math.abs(w - 20) < 0.01)).toBe(true);
+    expect(xs).toEqual([0, 20, 40, 60]);
+  });
+
+  test('low value is the minColor, high value is the maxColor', () => {
+    const t = makeTable({ columns: [{ field: 'signal' }] });
+    const svg = t.renderHeatmap([0, 1], {
+      width: 40, height: 16,
+      minColor: '#ff0000', maxColor: '#00ff00'
+    });
+    const rects = svg.querySelectorAll('rect');
+    expect(rects[0].getAttribute('fill')).toBe('rgb(255, 0, 0)');
+    expect(rects[1].getAttribute('fill')).toBe('rgb(0, 255, 0)');
+  });
+
+  test('all-equal series renders cells at maxColor (full intensity)', () => {
+    const t = makeTable({ columns: [{ field: 'signal' }] });
+    const svg = t.renderHeatmap([5, 5, 5], {
+      minColor: '#ff0000', maxColor: '#00ff00'
+    });
+    const rects = svg.querySelectorAll('rect');
+    for (const rect of rects) {
+      expect(rect.getAttribute('fill')).toBe('rgb(0, 255, 0)');
+    }
+  });
+
+  test('non-array / empty / all-NaN returns null', () => {
+    const t = makeTable({ columns: [{ field: 'signal' }] });
+    expect(t.renderHeatmap(null)).toBeNull();
+    expect(t.renderHeatmap([])).toBeNull();
+    expect(t.renderHeatmap('nope')).toBeNull();
+    expect(t.renderHeatmap([NaN, 'bad'])).toBeNull();
+  });
+});
+
+describe('Heatmap: cellType integration', () => {
+  test('column with cellType: "heatmap" renders an svg in the body cell', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'id' },
+        { field: 'signal', cellType: 'heatmap' }
+      ]
+    });
+    t.render();
+
+    const cells = document.querySelectorAll('td[data-field="signal"]');
+    expect(cells[0].querySelector('svg')).not.toBeNull();
+    expect(cells[1].querySelector('svg')).not.toBeNull();
+    expect(cells[2].querySelector('svg')).toBeNull();
+    expect(cells[3].querySelector('svg')).toBeNull();
+  });
+
+  test('column.heatmap options pass through to the renderer', () => {
+    const t = makeTable({
+      columns: [
+        { field: 'signal', cellType: 'heatmap', heatmap: { width: 120, height: 24, minColor: '#000', maxColor: '#fff' } }
+      ]
+    });
+    t.render();
+    const svg = document.querySelector('td[data-field="signal"] svg');
+    expect(svg.getAttribute('width')).toBe('120');
+    expect(svg.getAttribute('height')).toBe('24');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #128 (bars). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #128 merges.

- `column.cellType: 'heatmap'` renders an array-of-numbers as an inline `<svg>` with one `<rect>` per value. Each rect's fill is interpolated between `minColor` and `maxColor` based on the value's position in `[min, max]`. Per-column options on `column.heatmap`: `width` / `height` / `minColor` / `maxColor` (defaults 80×16, white → black).
- `table.renderHeatmap(values, options?)` is exposed publicly to match `renderSparkline` / `renderBars`.
- All-equal series renders `maxColor` — heatmaps read as \"saturated\" rather than \"blank\" when every reading is the same.
- Non-array / empty / all-`NaN` values render an empty cell, matching the sparkline / bars contract.
- Hex colour inputs (`#abc`, `#aabbcc`) are accepted; other formats fall back to the white → black default.

## Out of scope (still tracked on #58)
- Hover tooltip with the data values
- Animation on data change

## Tests
New file `test/heatmap-cell-type.test.js` — 7 cases:
- `<svg>` with one `<rect>` per value
- Cells span the viewport horizontally with no overlap
- Low value → `minColor`, high value → `maxColor`
- All-equal series → `maxColor`
- Non-array / empty / all-`NaN` returns `null`
- `cellType: 'heatmap'` integration: SVG appears in body cell
- `column.heatmap` options pass through to the renderer

Combined: 23/23 viz tests green (9 sparkline + 7 bars + 7 heatmap). Full suite: 84/85 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #58