### PR TITLE
feat(wp): TableCrafter.bootstrap() auto-instantiator

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3491,6 +3491,63 @@ class TableCrafter {
       this.dropdowns = [];
     }
   }
+
+  /**
+   * Auto-instantiate TableCrafter on every `[data-tc-bootstrap]` element
+   * inside the supplied scope (or the whole document when no scope is given).
+   * The bootstrap config is read from each element's `data-tc-config`
+   * attribute as JSON.
+   *
+   * Idempotent: re-running over the same DOM returns the existing instance
+   * for already-bootstrapped elements rather than constructing a duplicate.
+   * Malformed config emits a single console.warn per element and is
+   * skipped — one bad embed cannot break a page with several tables.
+   *
+   * Returns Map<HTMLElement, TableCrafter>.
+   */
+  static bootstrap(scope) {
+    if (typeof document === 'undefined') return new Map();
+    if (!TableCrafter._bootstrapped) TableCrafter._bootstrapped = new WeakMap();
+
+    let root = document;
+    if (typeof scope === 'string' && scope) {
+      root = document.querySelector(scope);
+      if (!root) return new Map();
+    } else if (scope && scope.querySelectorAll) {
+      root = scope;
+    }
+
+    const elements = root.querySelectorAll('[data-tc-bootstrap]');
+    const map = new Map();
+    for (const el of elements) {
+      // Idempotency: already bootstrapped → return the existing instance.
+      const prior = TableCrafter._bootstrapped.get(el);
+      if (prior) {
+        map.set(el, prior);
+        continue;
+      }
+
+      const raw = el.getAttribute('data-tc-config') || '';
+      let cfg = {};
+      if (raw) {
+        try {
+          cfg = JSON.parse(raw);
+        } catch (e) {
+          console.warn(`TableCrafter.bootstrap: invalid data-tc-config on element`, el);
+          continue;
+        }
+      }
+
+      try {
+        const instance = new TableCrafter(el, cfg);
+        TableCrafter._bootstrapped.set(el, instance);
+        map.set(el, instance);
+      } catch (e) {
+        console.warn('TableCrafter.bootstrap: failed to instantiate', e);
+      }
+    }
+    return map;
+  }
 }
 
 // Export for different module systems

--- a/test/wp-bootstrap.test.js
+++ b/test/wp-bootstrap.test.js
@@ -1,0 +1,87 @@
+/**
+ * TableCrafter.bootstrap helper (slice 1 of #54).
+ *
+ * Scans the document for `[data-tc-bootstrap]` elements, parses their
+ * `data-tc-config` JSON, and instantiates a TableCrafter on each. The
+ * surrounding WordPress plugin (PHP shortcode + REST endpoint + asset
+ * enqueue) lives in a separate repo and is out of scope here.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+function mount(html) {
+  document.body.innerHTML = html;
+}
+
+describe('TableCrafter.bootstrap()', () => {
+  test('instantiates a table for each [data-tc-bootstrap] element', () => {
+    mount(`
+      <div id="t1" data-tc-bootstrap data-tc-config='{"columns":[{"field":"id"}],"data":[{"id":1}]}'></div>
+      <div id="t2" data-tc-bootstrap data-tc-config='{"columns":[{"field":"id"}],"data":[{"id":2}]}'></div>
+      <div id="other"></div>
+    `);
+
+    const map = TableCrafter.bootstrap();
+    expect(map.size).toBe(2);
+    for (const instance of map.values()) {
+      expect(instance).toBeInstanceOf(TableCrafter);
+    }
+    // The non-bootstrap element is left alone.
+    expect(document.getElementById('other').children.length).toBe(0);
+  });
+
+  test('returns an empty Map when no [data-tc-bootstrap] elements exist', () => {
+    mount('<div id="other"></div>');
+    expect(TableCrafter.bootstrap().size).toBe(0);
+  });
+
+  test('re-running bootstrap is idempotent (no double instantiation)', () => {
+    mount('<div id="t" data-tc-bootstrap data-tc-config=\'{"columns":[{"field":"id"}],"data":[]}\'></div>');
+    const first = TableCrafter.bootstrap();
+    const firstInstance = first.get(document.getElementById('t'));
+
+    const second = TableCrafter.bootstrap();
+    const secondInstance = second.get(document.getElementById('t'));
+
+    expect(secondInstance).toBe(firstInstance);
+  });
+
+  test('malformed data-tc-config warns once and skips the element', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mount(`
+      <div id="t1" data-tc-bootstrap data-tc-config='not valid json'></div>
+      <div id="t2" data-tc-bootstrap data-tc-config='{"columns":[{"field":"id"}]}'></div>
+    `);
+
+    const map = TableCrafter.bootstrap();
+    expect(map.size).toBe(1);
+    expect(map.has(document.getElementById('t1'))).toBe(false);
+    expect(map.has(document.getElementById('t2'))).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  test('scoped selector restricts the scan', () => {
+    mount(`
+      <section id="region">
+        <div id="t1" data-tc-bootstrap data-tc-config='{"columns":[{"field":"id"}]}'></div>
+      </section>
+      <div id="t2" data-tc-bootstrap data-tc-config='{"columns":[{"field":"id"}]}'></div>
+    `);
+
+    const map = TableCrafter.bootstrap('#region');
+    expect(map.size).toBe(1);
+    expect(map.has(document.getElementById('t1'))).toBe(true);
+    expect(map.has(document.getElementById('t2'))).toBe(false);
+  });
+
+  test('empty data-tc-config is valid (uses defaults)', () => {
+    mount('<div id="t" data-tc-bootstrap></div>');
+    const map = TableCrafter.bootstrap();
+    expect(map.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #54. AC posted on the issue earlier in the session. The PHP shortcode + REST endpoint + asset enqueueing live in a separate WordPress plugin repo; this PR ships only the JS-side hook the wrapper needs.

- `TableCrafter.bootstrap(scope?)` — static method. Scans `[data-tc-bootstrap]` elements (in `scope` if provided, otherwise the whole document), reads JSON config from each element's `data-tc-config` attribute, and instantiates a `TableCrafter` on the element.
- Returns `Map<HTMLElement, TableCrafter>` so the wrapper can reach individual instances after bootstrap.
- **Idempotent**: re-running over the same DOM returns the prior instance via a `WeakMap` keyed by the element rather than double-constructing.
- Malformed JSON emits a `console.warn` per element and is skipped; one bad embed cannot break a page with several tables.
- Empty `data-tc-config` is valid and uses the engine's defaults.

Usage from a WP wrapper's enqueued script:
```js
document.addEventListener('DOMContentLoaded', () => TableCrafter.bootstrap());
```

## Out of scope (lives in the WP plugin repo)
- PHP shortcode handler (`[gravity_table id=\"…\"]`)
- WordPress REST endpoint that serves Gravity-Forms entries as JSON
- Asset enqueueing for the UMD bundle + stylesheet
- Admin UI for configuring tables

## Tests
New file `test/wp-bootstrap.test.js` — 6 cases:
- Instantiates on each `[data-tc-bootstrap]` element
- Empty Map when no matching elements
- Idempotent: returns existing instance on re-run
- Malformed JSON warns once and skips
- Scoped selector restricts the scan
- Empty `data-tc-config` is valid

Full suite: 67/68 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #54