### PR TITLE
feat(aggregation): groupBy + getGroupAggregates

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2707,6 +2707,55 @@ class TableCrafter {
    */
 
   /**
+   * Compute aggregates for every column that declared `column.aggregate`.
+   * Defaults to running over getFilteredData(); pass an explicit rows array
+   * for custom scopes (e.g. this.data for an unfiltered total).
+   */
+  getAggregates(rows) {
+    const source = Array.isArray(rows) ? rows : this.getFilteredData();
+    const out = {};
+    for (const column of (this.config.columns || [])) {
+      if (column.aggregate == null) continue;
+      out[column.field] = this._computeAggregate(column.aggregate, column.field, source);
+    }
+    return out;
+  }
+
+  /**
+   * One-shot aggregate. fn defaults to the column's declared aggregate.
+   * Returns null when no aggregate is configured and no fn is passed.
+   */
+  aggregate(field, fn, rows) {
+    const column = (this.config.columns || []).find(c => c.field === field);
+    const op = fn != null ? fn : (column && column.aggregate);
+    if (op == null) return null;
+    const source = Array.isArray(rows) ? rows : this.getFilteredData();
+    return this._computeAggregate(op, field, source);
+  }
+
+  _computeAggregate(op, field, source) {
+    if (typeof op === 'function') {
+      const values = source.map(r => r[field]);
+      return op(values, source);
+    }
+    if (op === 'count') {
+      return source.filter(r => r[field] != null).length;
+    }
+    const numeric = source
+      .filter(r => r[field] != null)
+      .map(r => Number(r[field]))
+      .filter(n => !Number.isNaN(n));
+    if (numeric.length === 0) return null;
+    switch (op) {
+      case 'sum': return numeric.reduce((a, b) => a + b, 0);
+      case 'avg': return numeric.reduce((a, b) => a + b, 0) / numeric.length;
+      case 'min': return Math.min(...numeric);
+      case 'max': return Math.max(...numeric);
+      default:    return null;
+    }
+  }
+
+  /**
    * Set current user context
    */
   setCurrentUser(user) {

--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2722,6 +2722,40 @@ class TableCrafter {
   }
 
   /**
+   * Group rows by a field. Returns Map<groupKey, rows[]> with insertion order
+   * matching the first-seen order of each group key. Honours an explicit
+   * rows argument (e.g. getFilteredData()) so callers can group only what
+   * they're showing rather than the whole dataset.
+   */
+  groupBy(field, rows) {
+    const source = Array.isArray(rows) ? rows : (this.data || []);
+    const groups = new Map();
+    for (const row of source) {
+      const key = row ? row[field] : undefined;
+      let bucket = groups.get(key);
+      if (!bucket) {
+        bucket = [];
+        groups.set(key, bucket);
+      }
+      bucket.push(row);
+    }
+    return groups;
+  }
+
+  /**
+   * Run every column.aggregate over each group. Returns Map<groupKey,
+   * { [aggField]: value }> with the same key ordering as groupBy().
+   */
+  getGroupAggregates(field, rows) {
+    const groups = this.groupBy(field, rows);
+    const out = new Map();
+    for (const [key, bucket] of groups.entries()) {
+      out.set(key, this.getAggregates(bucket));
+    }
+    return out;
+  }
+
+  /**
    * One-shot aggregate. fn defaults to the column's declared aggregate.
    * Returns null when no aggregate is configured and no fn is passed.
    */

--- a/test/aggregation-group-by.test.js
+++ b/test/aggregation-group-by.test.js
@@ -1,0 +1,99 @@
+/**
+ * Aggregation: group-by support (slice 2 of #48).
+ * Stacked on PR #111 (column.aggregate + getAggregates / aggregate API).
+ *
+ * Adds:
+ *   - groupBy(field) -> Map<groupKey, rows[]>
+ *   - getGroupAggregates(field) -> Map<groupKey, { [aggField]: value }>
+ *
+ * Footer / summary-row UI rendering and persistence of computed aggregates
+ * remain queued under #48.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, team: 'core',   qty: 10, price: 5  },
+  { id: 2, team: 'core',   qty: 20, price: 7  },
+  { id: 3, team: 'mobile', qty: 30, price: 11 },
+  { id: 4, team: 'mobile', qty: 5,  price: 13 },
+  { id: 5, team: null,     qty: 1,  price: 1  }
+];
+
+function makeTable(columns) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('groupBy(field)', () => {
+  test('returns a Map keyed by group value with the matching rows', () => {
+    const t = makeTable([{ field: 'team' }, { field: 'qty' }]);
+    const groups = t.groupBy('team');
+
+    expect(groups.size).toBe(3);
+    expect(groups.get('core')).toEqual([
+      { id: 1, team: 'core', qty: 10, price: 5 },
+      { id: 2, team: 'core', qty: 20, price: 7 }
+    ]);
+    expect(groups.get('mobile')).toHaveLength(2);
+    expect(groups.get(null)).toEqual([{ id: 5, team: null, qty: 1, price: 1 }]);
+  });
+
+  test('returns Map preserves first-seen order of group keys', () => {
+    const t = makeTable([{ field: 'team' }]);
+    const keys = Array.from(t.groupBy('team').keys());
+    expect(keys).toEqual(['core', 'mobile', null]);
+  });
+
+  test('respects the supplied rows array (filtered subset)', () => {
+    const t = makeTable([{ field: 'team' }]);
+    const subset = data.filter(r => r.team !== null);
+    const groups = t.groupBy('team', subset);
+    expect(groups.size).toBe(2);
+    expect(groups.has(null)).toBe(false);
+  });
+
+  test('unknown field yields a single group keyed by undefined', () => {
+    const t = makeTable([{ field: 'team' }]);
+    const groups = t.groupBy('ghost');
+    expect(groups.size).toBe(1);
+    expect(groups.get(undefined)).toHaveLength(data.length);
+  });
+});
+
+describe('getGroupAggregates(field)', () => {
+  test('runs every column.aggregate over each group', () => {
+    const t = makeTable([
+      { field: 'team' },
+      { field: 'qty', aggregate: 'sum' },
+      { field: 'price', aggregate: 'avg' }
+    ]);
+    const groupAggs = t.getGroupAggregates('team');
+
+    expect(groupAggs.get('core')).toEqual({ qty: 30, price: 6 });
+    expect(groupAggs.get('mobile')).toEqual({ qty: 35, price: 12 });
+    expect(groupAggs.get(null)).toEqual({ qty: 1, price: 1 });
+  });
+
+  test('only includes fields that declared aggregate', () => {
+    const t = makeTable([
+      { field: 'team' },
+      { field: 'qty', aggregate: 'sum' }
+    ]);
+    const groupAggs = t.getGroupAggregates('team');
+    expect(Object.keys(groupAggs.get('core'))).toEqual(['qty']);
+  });
+
+  test('honours an explicit rows argument (post-filter scope)', () => {
+    const t = makeTable([
+      { field: 'team' },
+      { field: 'qty', aggregate: 'sum' }
+    ]);
+    const subset = data.filter(r => r.qty >= 10);
+    const groupAggs = t.getGroupAggregates('team', subset);
+
+    expect(groupAggs.get('core')).toEqual({ qty: 30 });
+    expect(groupAggs.get('mobile')).toEqual({ qty: 30 }); // only qty=30 from subset
+    expect(groupAggs.has(null)).toBe(false); // qty=1 row excluded
+  });
+});

--- a/test/aggregation.test.js
+++ b/test/aggregation.test.js
@@ -1,0 +1,105 @@
+/**
+ * Aggregation foundation (slice 1 of #48).
+ *
+ * Adds column.aggregate config + getAggregates() / aggregate() helpers.
+ * Footer-row UI, group-by per-group totals, and state persistence remain
+ * queued under #48 follow-ups.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [
+  { id: 1, qty: 10, price: 5.5,   note: 'a'  },
+  { id: 2, qty: 20, price: 'n/a', note: null },
+  { id: 3, qty: 30, price: 7.0,   note: 'b'  },
+  { id: 4, qty: 0,  price: 12.5,  note: 'c'  }
+];
+
+function makeTable(columns) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns });
+}
+
+describe('Aggregation: built-in operators', () => {
+  test('sum over numeric values', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.getAggregates().qty).toBe(60);
+  });
+
+  test('avg over numeric values, ignoring non-numeric', () => {
+    const t = makeTable([{ field: 'price', aggregate: 'avg' }]);
+    expect(t.getAggregates().price).toBeCloseTo((5.5 + 7.0 + 12.5) / 3);
+  });
+
+  test('count counts non-null cells', () => {
+    const t = makeTable([{ field: 'note', aggregate: 'count' }]);
+    expect(t.getAggregates().note).toBe(3); // null skipped
+  });
+
+  test('min and max ignore non-numeric cells', () => {
+    const t = makeTable([
+      { field: 'qty',   aggregate: 'min' },
+      { field: 'price', aggregate: 'max' }
+    ]);
+    const agg = t.getAggregates();
+    expect(agg.qty).toBe(0);
+    expect(agg.price).toBe(12.5);
+  });
+
+  test('numeric ops on a column with no numeric cells return null', () => {
+    const t = makeTable([{ field: 'note', aggregate: 'sum' }]);
+    expect(t.getAggregates().note).toBeNull();
+  });
+});
+
+describe('Aggregation: custom function', () => {
+  test('receives (values, rows) and the return value lands as-is', () => {
+    const fn = jest.fn((values, rows) => `${rows.length} rows / ${values.length} qtys`);
+    const t = makeTable([{ field: 'qty', aggregate: fn }]);
+
+    const agg = t.getAggregates();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toEqual([10, 20, 30, 0]);   // values
+    expect(fn.mock.calls[0][1]).toHaveLength(4);             // rows
+    expect(agg.qty).toBe('4 rows / 4 qtys');
+  });
+});
+
+describe('Aggregation: getAggregates() shape', () => {
+  test('only includes fields that declared aggregate', () => {
+    const t = makeTable([
+      { field: 'id' },
+      { field: 'qty', aggregate: 'sum' },
+      { field: 'price' }
+    ]);
+    expect(Object.keys(t.getAggregates())).toEqual(['qty']);
+  });
+
+  test('uses getFilteredData() when rows arg is omitted', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    t.searchTerm = 'b'; // 'b' only appears in row 3's note field
+    expect(t.getAggregates().qty).toBe(30); // qty of just row 3
+  });
+
+  test('honours an explicit rows argument', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.getAggregates([{ qty: 1 }, { qty: 2 }]).qty).toBe(3);
+  });
+});
+
+describe('aggregate() one-shot helper', () => {
+  test('honours the column-declared aggregate when no fn passed', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.aggregate('qty')).toBe(60);
+  });
+
+  test('explicit fn overrides the declared aggregate', () => {
+    const t = makeTable([{ field: 'qty', aggregate: 'sum' }]);
+    expect(t.aggregate('qty', 'avg')).toBe(15);
+  });
+
+  test('returns null when neither column nor explicit fn is configured', () => {
+    const t = makeTable([{ field: 'qty' }]);
+    expect(t.aggregate('qty')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #111 (`column.aggregate` + `getAggregates` / `aggregate` API). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #111 merges.

- `groupBy(field, rows?)` returns `Map<groupKey, rows[]>` with insertion order matching the first-seen order of each group key. Honours an explicit `rows` argument so callers can group only the filtered/sorted subset they're displaying rather than the whole dataset.
- `getGroupAggregates(field, rows?)` runs every `column.aggregate` over each group and returns `Map<groupKey, { [aggField]: value }>` with the same key ordering. Composes cleanly with the existing `getAggregates()` helper — each group is just another rows source fed back through the same per-field pipeline.
- Unknown field falls back to a single group keyed by `undefined` so consumers don't need a defensive check before grouping.

## Out of scope (still tracked on #48)
- Footer / summary-row UI rendering
- Sticky group headers in the rendered table
- Persistence of computed aggregates across sessions

## Tests
New file `test/aggregation-group-by.test.js` — 7 cases:
- `groupBy` returns the right rows under each key
- Map preserves first-seen order of group keys
- Honours an explicit `rows` argument
- Unknown field → single group keyed by `undefined`
- `getGroupAggregates` runs every declared aggregate per group
- Only includes fields that declared `aggregate`
- Honours an explicit `rows` argument (post-filter scope)

Combined: 19/19 aggregation tests green (12 foundation + 7 group-by). Full suite: 80/81 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #48