### PR TITLE
feat(formulas): string functions + string literals

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2743,15 +2743,32 @@ class TableCrafter {
       return null;
     }
 
-    // Resolve placeholders to numeric values up front so the parser only sees
-    // numbers, ops, parens, commas, and function names.
+    // Resolve placeholders, preserving type so string-functions like CONCAT /
+    // LENGTH / UPPER / LOWER can read text values directly. Arithmetic /
+    // comparison branches still coerce via Number(); a non-numeric value used
+    // there flows through to NaN and the outer guard turns it into null.
     const resolved = [];
     for (const tok of tokens) {
       if (tok.type === 'placeholder') {
         if (!row || !(tok.name in row)) return null;
-        const num = Number(row[tok.name]);
-        if (Number.isNaN(num)) return null;
-        resolved.push({ type: 'number', value: num });
+        const v = row[tok.name];
+        if (typeof v === 'number') {
+          resolved.push({ type: 'number', value: v });
+        } else if (typeof v === 'string') {
+          resolved.push({ type: 'string', value: v });
+        } else if (typeof v === 'boolean') {
+          resolved.push({ type: 'number', value: v ? 1 : 0 });
+        } else if (v === null || v === undefined) {
+          return null;
+        } else {
+          // Try numeric coercion first; otherwise fall back to string.
+          const num = Number(v);
+          if (!Number.isNaN(num)) {
+            resolved.push({ type: 'number', value: num });
+          } else {
+            resolved.push({ type: 'string', value: String(v) });
+          }
+        }
       } else {
         resolved.push(tok);
       }
@@ -2763,7 +2780,8 @@ class TableCrafter {
       warnOnce(ctx.error || 'parse error');
       return null;
     }
-    if (result === null || !Number.isFinite(result)) return null;
+    if (result === null) return null;
+    if (typeof result === 'number' && !Number.isFinite(result)) return null;
     return result;
   }
 
@@ -2827,6 +2845,10 @@ class TableCrafter {
     const tok = ctx.tokens[ctx.pos];
 
     if (tok.type === 'number') {
+      ctx.pos++;
+      return tok.value;
+    }
+    if (tok.type === 'string') {
       ctx.pos++;
       return tok.value;
     }
@@ -2894,6 +2916,17 @@ class TableCrafter {
       case 'MIN':   return args.length >= 1 ? Math.min(...args) : null;
       case 'MAX':   return args.length >= 1 ? Math.max(...args) : null;
       case 'IF':    return args.length === 3 ? (args[0] ? args[1] : args[2]) : null;
+      case 'CONCAT':
+        return args.map(a => a == null ? '' : String(a)).join('');
+      case 'LENGTH':
+        if (args.length !== 1) return null;
+        return String(args[0] == null ? '' : args[0]).length;
+      case 'UPPER':
+        if (args.length !== 1) return null;
+        return String(args[0] == null ? '' : args[0]).toUpperCase();
+      case 'LOWER':
+        if (args.length !== 1) return null;
+        return String(args[0] == null ? '' : args[0]).toLowerCase();
       default:      return null;
     }
   }
@@ -2938,6 +2971,14 @@ class TableCrafter {
         const name = s.slice(i + 1, end);
         if (!/^[a-zA-Z_][\w]*$/.test(name)) return null;
         tokens.push({ type: 'placeholder', name });
+        i = end + 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        const quote = ch;
+        const end = s.indexOf(quote, i + 1);
+        if (end === -1) return null;
+        tokens.push({ type: 'string', value: s.slice(i + 1, end) });
         i = end + 1;
         continue;
       }

--- a/test/formula-strings.test.js
+++ b/test/formula-strings.test.js
@@ -1,0 +1,70 @@
+/**
+ * Formula string functions (slice 4 of #47).
+ * Stacked on PR #114 (comparison operators + IF).
+ *
+ * Adds CONCAT, LENGTH, UPPER, LOWER. The numeric grammar still owns the
+ * arithmetic / comparison side; these helpers operate on the {field}
+ * placeholder values without breaking the safe-eval guarantee.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+function makeTable() {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', {
+    columns: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+    data: []
+  });
+}
+
+const ev = (formula, row = {}) => makeTable().evaluateFormula(formula, row);
+
+describe('Formula: CONCAT', () => {
+  test('joins string and numeric placeholders into a single string', () => {
+    expect(ev('CONCAT({a}, "-", {b})', { a: 'foo', b: 42 })).toBe('foo-42');
+  });
+
+  test('CONCAT with quoted string literals', () => {
+    expect(ev('CONCAT("hello, ", {a})', { a: 'world' })).toBe('hello, world');
+  });
+
+  test('empty CONCAT returns empty string', () => {
+    expect(ev('CONCAT()', {})).toBe('');
+  });
+});
+
+describe('Formula: LENGTH', () => {
+  test('LENGTH of a string field returns its character count', () => {
+    expect(ev('LENGTH({a})', { a: 'hello' })).toBe(5);
+  });
+
+  test('LENGTH of a number stringifies before counting', () => {
+    expect(ev('LENGTH({a})', { a: 12345 })).toBe(5);
+  });
+
+  test('LENGTH of "" is 0', () => {
+    expect(ev('LENGTH({a})', { a: '' })).toBe(0);
+  });
+
+  test('LENGTH of a literal string', () => {
+    expect(ev('LENGTH("abc")', {})).toBe(3);
+  });
+
+  test('LENGTH wrong arity returns null', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(ev('LENGTH()', {})).toBeNull();
+    expect(ev('LENGTH({a}, "extra")', { a: 'hi' })).toBeNull();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('Formula: UPPER / LOWER', () => {
+  test('UPPER and LOWER round-trip', () => {
+    expect(ev('UPPER({a})', { a: 'hello' })).toBe('HELLO');
+    expect(ev('LOWER({a})', { a: 'WORLD' })).toBe('world');
+  });
+
+  test('UPPER / LOWER on numeric placeholder coerces to string', () => {
+    expect(ev('UPPER({a})', { a: 42 })).toBe('42');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #114 (comparison operators + IF). Targets that branch so reviewers see only the additive diff; GitHub will retarget at `main` when #114 merges.

- Tokeniser now recognises `\"...\"`- and `'...'`-quoted string literals.
- Parser factor accepts a string token and returns its value directly.
- Placeholder resolution preserves type: numbers stay numeric, strings stay string, booleans become 0/1 numbers, missing keys still abort. Arithmetic / comparison still coerce via `Number()` so non-numeric usage flows through to `NaN` and the outer guard turns that into `null` — preserving the existing strict semantics for `{a} * 2` with `a: 'hello'`.
- `evaluateFormula`'s terminal guard only nullifies non-finite **numbers** now; string returns pass through unchanged so `CONCAT` / `UPPER` / `LOWER` can produce real string output.
- New functions:
  - `CONCAT(...args)` joins with `\"\"` (variadic; `CONCAT()` returns `\"\"`)
  - `LENGTH(value)` returns the character count of `String(value)`
  - `UPPER(value)` / `LOWER(value)` wrap `String#toUpperCase` / `toLowerCase`
- Wrong arity returns `null` via the existing function-call error path.

## Out of scope (still tracked on #47)
- `DATE` / `DATEDIFF` / `NOW` / `TODAY`
- Regex helpers (`MATCH`, `REPLACE`)
- `SUM({field})` / `AVG({field})` cross-row references (bridge to #48 aggregation)
- Formula bar UI for live cell entry

## Tests
New file `test/formula-strings.test.js` — 10 cases:
- `CONCAT` joins string + numeric placeholders + literals
- `CONCAT()` returns `\"\"`
- `LENGTH` of string / number / empty / literal
- `LENGTH` wrong arity → `null`
- `UPPER` / `LOWER` round-trip
- `UPPER` / `LOWER` on numeric placeholder coerces to string

Combined: 46/46 formula tests green (13 evaluator + 13 functions + 10 if + 10 strings). Full suite: 107/108 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #47