### PR TITLE
feat(testing): snapshotHTML() deterministic DOM serialiser

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -2707,6 +2707,80 @@ class TableCrafter {
    */
 
   /**
+   * Render the current DOM as a deterministic HTML string. Two snapshots of
+   * the same logical state produce byte-identical output so consumers can
+   * pair this with Jest's toMatchSnapshot() to catch unintended visual
+   * regressions in CI without a real browser.
+   *
+   * Normalisation:
+   *   - Attributes alphabetised per element.
+   *   - Inline `width: N%` styles rounded to 1 decimal place so floating-
+   *     point drift across browsers does not break snapshots.
+   *
+   * options.scope:
+   *   - 'table' (default) returns just the `<table>` markup.
+   *   - 'wrapper' returns the full `.tc-wrapper` markup.
+   *
+   * Pure read — never triggers a render.
+   */
+  snapshotHTML(options) {
+    const opts = options || {};
+    const scope = opts.scope || 'table';
+    const wrapper = this.container && this.container.querySelector('.tc-wrapper');
+    if (!wrapper) return '';
+    const root = scope === 'wrapper' ? wrapper : (wrapper.querySelector('table') || wrapper);
+    return this._serialiseSnapshot(root);
+  }
+
+  _serialiseSnapshot(node) {
+    if (!node) return '';
+    if (node.nodeType === 3) return node.nodeValue;
+    if (node.nodeType !== 1) return '';
+
+    const tag = node.tagName.toLowerCase();
+    const attrs = Array.from(node.attributes || []).slice();
+    attrs.sort((a, b) => a.name.localeCompare(b.name));
+
+    const parts = [`<${tag}`];
+    for (const attr of attrs) {
+      let value = attr.value;
+      if (attr.name === 'style' && value) {
+        value = this._normaliseStyleString(value);
+      }
+      parts.push(` ${attr.name}="${this._escapeSnapshotAttr(value)}"`);
+    }
+
+    const voidTags = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+                      'link', 'meta', 'source', 'track', 'wbr'];
+    if (voidTags.indexOf(tag) !== -1) {
+      parts.push('/>');
+      return parts.join('');
+    }
+
+    parts.push('>');
+    for (const child of node.childNodes) {
+      parts.push(this._serialiseSnapshot(child));
+    }
+    parts.push(`</${tag}>`);
+    return parts.join('');
+  }
+
+  _normaliseStyleString(style) {
+    return style
+      .split(';')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(part => part.replace(/(\d+\.\d+)%/g, (m, num) => `${parseFloat(parseFloat(num).toFixed(1))}%`))
+      .join('; ');
+  }
+
+  _escapeSnapshotAttr(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
    * Set current user context
    */
   setCurrentUser(user) {

--- a/test/visual-snapshot.test.js
+++ b/test/visual-snapshot.test.js
@@ -1,0 +1,106 @@
+/**
+ * Visual snapshot foundation (slice 1 of #57).
+ *
+ * Lands a deterministic snapshotHTML() helper that consumers can pair
+ * with Jest's toMatchSnapshot() to detect unintended visual regressions
+ * in CI without spinning up a real browser.
+ *
+ * Pixel-perfect screenshot diffing via Puppeteer / Playwright remains a
+ * separate ticket; this PR ships the lightweight DOM-string flavour.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+const data = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }];
+const columns = [{ field: 'id' }, { field: 'name' }];
+
+function makeTable(extra = {}) {
+  document.body.innerHTML = '<div id="t"></div>';
+  return new TableCrafter('#t', { data, columns, ...extra });
+}
+
+describe('snapshotHTML: determinism', () => {
+  test('two consecutive calls on the same state return identical strings', () => {
+    const t = makeTable();
+    t.render();
+    expect(t.snapshotHTML()).toBe(t.snapshotHTML());
+  });
+
+  test('changing search term + re-rendering changes the snapshot', () => {
+    const t = makeTable();
+    t.render();
+    const before = t.snapshotHTML();
+
+    t.searchTerm = 'A';
+    t.render();
+    const after = t.snapshotHTML();
+
+    expect(after).not.toBe(before);
+  });
+});
+
+describe('snapshotHTML: normalisation', () => {
+  test('attributes are alphabetically sorted per element', () => {
+    const t = makeTable();
+    t.render();
+    // Construct an element with attributes in a "wrong" order to confirm
+    // the normaliser sorts them. Insert into the wrapper so the snapshot
+    // includes it.
+    const wrapper = document.querySelector('.tc-wrapper');
+    const probe = document.createElement('span');
+    probe.setAttribute('z-attr', '1');
+    probe.setAttribute('a-attr', '2');
+    probe.setAttribute('m-attr', '3');
+    wrapper.appendChild(probe);
+
+    const html = t.snapshotHTML({ scope: 'wrapper' });
+    // The substring should have a- before m- before z-
+    const aIdx = html.indexOf('a-attr');
+    const mIdx = html.indexOf('m-attr');
+    const zIdx = html.indexOf('z-attr');
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(mIdx).toBeGreaterThan(aIdx);
+    expect(zIdx).toBeGreaterThan(mIdx);
+  });
+
+  test('inline width percentages are rounded to 1 decimal place', () => {
+    const t = makeTable();
+    t.render();
+    const wrapper = document.querySelector('.tc-wrapper');
+    const probe = document.createElement('div');
+    probe.setAttribute('style', 'width: 33.33333333%; color: red');
+    wrapper.appendChild(probe);
+
+    const html = t.snapshotHTML({ scope: 'wrapper' });
+    expect(html).toContain('width: 33.3%');
+    expect(html).not.toContain('33.33333333');
+  });
+});
+
+describe('snapshotHTML: scope', () => {
+  test('default scope returns the table-only markup', () => {
+    const t = makeTable();
+    t.render();
+    const html = t.snapshotHTML();
+    expect(html.startsWith('<table')).toBe(true);
+    expect(html).not.toContain('tc-wrapper');
+  });
+
+  test('scope: "wrapper" returns the full .tc-wrapper markup', () => {
+    const t = makeTable();
+    t.render();
+    const html = t.snapshotHTML({ scope: 'wrapper' });
+    expect(html.startsWith('<div')).toBe(true);
+    expect(html).toContain('class="tc-wrapper"');
+  });
+});
+
+describe('snapshotHTML: pure read', () => {
+  test('does not trigger a render', () => {
+    const t = makeTable();
+    t.render();
+    const renderSpy = jest.spyOn(t, 'render');
+    t.snapshotHTML();
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #57. AC posted on the issue earlier in the session.

Pixel-perfect screenshot diffing via Puppeteer / Playwright stays on the docket as a separate ticket; this PR ships a lightweight DOM-string flavour that consumers can pair with Jest's `toMatchSnapshot()` to catch unintended visual regressions in CI without a real browser.

- `snapshotHTML(options?)` returns the rendered DOM as a deterministic HTML string. Two calls on the same logical state produce byte-identical output.
- Normalisation:
  - Attributes sorted alphabetically per element.
  - Inline `width: N%` styles rounded to 1 decimal place so floating-point drift across runtime engines doesn't break snapshots.
  - Style strings normalised to `prop: value; prop: value` shape.
- `options.scope`: `'table'` (default) returns just the `<table>` markup; `'wrapper'` returns the full `.tc-wrapper` markup including search / pagination / export chrome.
- **Pure read** — never triggers a render. Spy-on-render verified.
- Void elements (`<img>`, `<input>`, etc.) emit self-closing tags.

## Out of scope (still tracked on #57)
- Pixel-perfect screenshot diffing
- Full-page snapshots that include surrounding non-table chrome
- Snapshot history / git-tracked golden files (consumer's CI concern)

## Tests
New file `test/visual-snapshot.test.js` — 7 cases:
- Two consecutive calls return identical strings
- Mutating searchTerm + re-rendering changes the snapshot
- Attributes sorted alphabetically per element
- Inline `width: 33.33333333%` rounds to `33.3%`
- Default scope returns table-only markup
- `scope: 'wrapper'` returns full wrapper markup
- Calling `snapshotHTML()` does not trigger a render

Full suite: 68/69 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #57