### PR TITLE
feat(testing): TableCrafter.getBrowserSupport() capability probe

### DIFF
--- a/src/tablecrafter.js
+++ b/src/tablecrafter.js
@@ -3491,6 +3491,43 @@ class TableCrafter {
       this.dropdowns = [];
     }
   }
+
+  /**
+   * Read-only probe of the runtime's Web Platform features. Consumers can
+   * pair this with `minimumBrowserSupportNotice()` to render a graceful
+   * "your browser is too old" banner when `requiredFeaturesAvailable` is
+   * `false`. Never mutates global state and never throws — every probe is
+   * wrapped so a missing `CSS` / `ResizeObserver` / etc. is just `false`.
+   */
+  static getBrowserSupport() {
+    const probe = (fn) => { try { return Boolean(fn()); } catch (_) { return false; } };
+
+    const intl = probe(() => typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function' && typeof Intl.DateTimeFormat === 'function');
+    const intlPluralRules = probe(() => typeof Intl !== 'undefined' && typeof Intl.PluralRules === 'function');
+    const resizeObserver = probe(() => typeof ResizeObserver !== 'undefined');
+    const performanceNow = probe(() => typeof performance !== 'undefined' && typeof performance.now === 'function');
+    const svgInHtml = probe(() => typeof SVGElement !== 'undefined' && typeof document !== 'undefined' && typeof document.createElementNS === 'function');
+    const abortController = probe(() => typeof AbortController !== 'undefined');
+    const cssCustomProperties = probe(() => typeof CSS !== 'undefined' && typeof CSS.supports === 'function' && CSS.supports('--x', '0'));
+
+    // Required features: the bare minimum the engine relies on.
+    const requiredFeaturesAvailable = intl && performanceNow && abortController;
+
+    return {
+      intl,
+      intlPluralRules,
+      resizeObserver,
+      performanceNow,
+      svgInHtml,
+      abortController,
+      cssCustomProperties,
+      requiredFeaturesAvailable
+    };
+  }
+
+  static minimumBrowserSupportNotice() {
+    return 'TableCrafter requires Chrome 88+, Firefox 89+, Safari 15+, or Edge 88+. Older browsers may render the table but will be missing internationalisation, abortable loads, and high-resolution timing.';
+  }
 }
 
 // Export for different module systems

--- a/test/browser-support.test.js
+++ b/test/browser-support.test.js
@@ -1,0 +1,63 @@
+/**
+ * Browser support detection (slice 1 of #56).
+ *
+ * Read-only capability probe consumers can use to surface a graceful
+ * "your browser is too old" banner. Cross-browser CI matrix and
+ * polyfill bundling remain queued elsewhere.
+ */
+
+const TableCrafter = require('../src/tablecrafter');
+
+describe('TableCrafter.getBrowserSupport()', () => {
+  test('returns an object with the documented keys', () => {
+    const support = TableCrafter.getBrowserSupport();
+
+    expect(support).toEqual(expect.objectContaining({
+      intl: expect.any(Boolean),
+      intlPluralRules: expect.any(Boolean),
+      resizeObserver: expect.any(Boolean),
+      performanceNow: expect.any(Boolean),
+      svgInHtml: expect.any(Boolean),
+      abortController: expect.any(Boolean),
+      cssCustomProperties: expect.any(Boolean),
+      requiredFeaturesAvailable: expect.any(Boolean)
+    }));
+  });
+
+  test('jsdom test environment satisfies the required features', () => {
+    expect(TableCrafter.getBrowserSupport().requiredFeaturesAvailable).toBe(true);
+  });
+
+  test('removing Intl flips intl + requiredFeaturesAvailable to false', () => {
+    const originalIntl = global.Intl;
+    delete global.Intl;
+    try {
+      const support = TableCrafter.getBrowserSupport();
+      expect(support.intl).toBe(false);
+      expect(support.requiredFeaturesAvailable).toBe(false);
+    } finally {
+      global.Intl = originalIntl;
+    }
+  });
+
+  test('does not throw when CSS / ResizeObserver / etc. are absent', () => {
+    const originalCSS = global.CSS;
+    const originalRO = global.ResizeObserver;
+    delete global.CSS;
+    delete global.ResizeObserver;
+    try {
+      expect(() => TableCrafter.getBrowserSupport()).not.toThrow();
+    } finally {
+      global.CSS = originalCSS;
+      global.ResizeObserver = originalRO;
+    }
+  });
+});
+
+describe('TableCrafter.minimumBrowserSupportNotice()', () => {
+  test('returns a non-empty string', () => {
+    const notice = TableCrafter.minimumBrowserSupportNotice();
+    expect(typeof notice).toBe('string');
+    expect(notice.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation slice for #56. AC posted on the issue earlier in the session.

A Playwright / Puppeteer cross-browser CI matrix stays as a separate ticket; this PR ships the runtime-side detection that the matrix and any consumer \"your browser is too old\" banner can both read.

- `TableCrafter.getBrowserSupport()` returns:
  ```js
  {
    intl, intlPluralRules, resizeObserver, performanceNow,
    svgInHtml, abortController, cssCustomProperties,
    requiredFeaturesAvailable
  }
  ```
  Each value is a boolean. Read-only — never mutates `globalThis`, never throws (every probe wrapped). Missing `CSS` / `ResizeObserver` / etc. just resolve to `false`.
- `requiredFeaturesAvailable` is the consumer-friendly summary: `true` exactly when `intl` + `performanceNow` + `abortController` are all present (the bare minimum the engine depends on).
- `TableCrafter.minimumBrowserSupportNotice()` returns a human-readable string consumers can drop into a banner when `requiredFeaturesAvailable` is `false`.

## Out of scope (still tracked elsewhere)
- Actual Playwright / Puppeteer cross-browser CI matrix
- `package.json` `browserslist` entry
- `core-js` polyfill bundling

## Tests
New file `test/browser-support.test.js` — 5 cases:
- Returns documented shape; values are booleans
- jsdom test environment satisfies required features
- Removing `Intl` flips `intl` and `requiredFeaturesAvailable` to `false`
- Doesn't throw when `CSS` / `ResizeObserver` are absent
- `minimumBrowserSupportNotice()` returns a non-empty string

Full suite: 66/67 pass. The remaining red is the pre-existing `should load data from URL` failure tracked in #71 (fix on PR #75); unrelated.

Refs #56