### PR TITLE
chore: fix sync_svn.sh paths + guard against free/pro cross-wire

### DIFF
--- a/sync_svn.sh
+++ b/sync_svn.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 
 # Configuration
+# -----------------------------------------------------------------------------
+# IMPORTANT: "free" and "pro" are DIVERGENT products with separate release
+# channels. Do not cross-wire them.
+#   FREE = this plugin, tablecrafter-wp-data-tables  ->  WordPress.org SVN (here)
+#   PRO  = gravity-tables (data-tables-for-gravity-forms)  ->  Freemius ONLY
+# The PRO plugin must NEVER be synced to this (free) wp.org SVN repo. The guards
+# below refuse to run if GIT_PATH is not the free plugin or SVN_PATH is not the
+# free plugin's wp.org repo.
+# -----------------------------------------------------------------------------
 PLUGIN_SLUG="tablecrafter-wp-data-tables"
-SVN_PATH="/Users/isupercoder/websites/tablecrafter/app/public/wp-content/plugins/tablecrafter-svn" 
-GIT_PATH="/Users/isupercoder/websites/tablecrafter/app/public/wp-content/plugins/tablecrafter-wp-data-tables"
+# Canonical free-plugin git checkout (the source of the release to publish).
+# Was a stale clone under ~/websites/tablecrafter/...; the live repo is here:
+GIT_PATH="/Users/isupercoder/websites/wp-data-tables"
+# Local working copy of the free plugin's wp.org SVN repo (svn co
+# https://plugins.svn.wordpress.org/tablecrafter-wp-data-tables/ <path>):
+SVN_PATH="/Users/isupercoder/websites/tablecrafter/app/public/wp-content/plugins/tablecrafter-svn"
 IGNORE_FILE=".svnignore"
 
 # Color codes
@@ -21,6 +34,22 @@ fi
 
 if [ ! -d "$GIT_PATH" ]; then
     echo -e "${RED}Error: Git directory not found at $GIT_PATH${NC}"
+    exit 1
+fi
+
+# Guard 1 (anti cross-wire): GIT_PATH must be the FREE plugin. The PRO plugin
+# (gravity-tables, text domain "gravity-tables") ships via Freemius, never here.
+if ! grep -rql "Text Domain: ${PLUGIN_SLUG}" "$GIT_PATH"/*.php 2>/dev/null; then
+    echo -e "${RED}Error: GIT_PATH ($GIT_PATH) is not the '${PLUGIN_SLUG}' plugin.${NC}"
+    echo -e "${RED}Refusing to sync — the PRO plugin must never be published to this free wp.org repo.${NC}"
+    exit 1
+fi
+
+# Guard 2 (anti cross-wire): SVN_PATH must be the FREE plugin's wp.org repo.
+SVN_URL="$(svn info "$SVN_PATH" 2>/dev/null | awk -F': ' '/^URL/{print $2; exit}')"
+if [[ "$SVN_URL" != *"/${PLUGIN_SLUG}" ]]; then
+    echo -e "${RED}Error: SVN_PATH is not the '${PLUGIN_SLUG}' wp.org repo (URL: ${SVN_URL:-unknown}).${NC}"
+    echo -e "${RED}Refusing to sync to avoid cross-wiring free/pro.${NC}"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

`sync_svn.sh` referenced stale paths under `~/websites/tablecrafter/...` (an old second clone of the free plugin). It now points `GIT_PATH` at the canonical repo (`~/websites/wp-data-tables`) so the wp.org SVN sync publishes the actual released source.

Adds two guards that refuse to run if the free/pro channels are crossed:
1. `GIT_PATH` must contain the free plugin's text domain `tablecrafter-wp-data-tables`. The **pro** plugin (`gravity-tables`) ships via **Freemius only** and must never reach this wp.org SVN repo.
2. `SVN_PATH`'s working-copy URL must be the free plugin's wp.org repo.

## Verification

- `bash -n` clean.
- Guard 1 PASSES on the free repo, **REJECTS** the gravity-tables (pro) repo.
- Guard 2 PASSES (`URL: https://plugins.svn.wordpress.org/tablecrafter-wp-data-tables`).

## Out of scope (still human-gated)

The actual SVN publish needs wp.org credentials and reconciling trunk (currently **3.5.4**) up through **3.5.6** (3.5.5 + 3.5.6 are missing from SVN). This PR only fixes/hardens the config.